### PR TITLE
Some fields and calls is unreadable in dark theme, using Android Studio.

### DIFF
--- a/src/colors/Material Theme - Darker.xml
+++ b/src/colors/Material Theme - Darker.xml
@@ -95,7 +95,7 @@
     </option>
     <option name="BNF_KEYWORD">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="BNF_NUMBER">
@@ -110,7 +110,7 @@
     </option>
     <option name="CLASS_REFERENCE">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
@@ -329,7 +329,7 @@
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
@@ -701,7 +701,7 @@
     </option>
     <option name="INSTANCE_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -713,12 +713,12 @@
     </option>
     <option name="Instance field">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="Instance property reference ID">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="JAVA_COMMA">
@@ -758,7 +758,7 @@
     </option>
     <option name="JFLEX_MACROS_REF">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="EFFECT_TYPE" value="-1" />
       </value>
     </option>
@@ -1216,27 +1216,27 @@
     </option>
     <option name="STATIC_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="Static method access">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="Static property reference ID">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
@@ -1388,7 +1388,7 @@
     </option>
     <option name="XPATH.XPATH_NAME">
       <value>
-        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FOREGROUND" value="99CCFF" />
       </value>
     </option>
     <option name="XPATH.XPATH_VARIABLE">


### PR DESCRIPTION
There is some occurrences of a dark foreground in dark theme, this is unreadable in some files.
If you open a Java file, or use the theme in android studio you'll see this problems with classes fields and static method calls.
You can see above:
![screen shot 2015-10-07 at 2 10 55 pm](https://cloud.githubusercontent.com/assets/5085965/10345075/5f1d4c9a-6cfd-11e5-9748-39bba8ab30ba.png)
