### PR TITLE
Adding Latest Rubymine + Adding ES6 and ES to javascript icon class

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.chrisrm.idea.MaterialThemeUI</id>
     <name>Material Theme UI</name>
-    <version>0.1.9</version>
+    <version>0.1.10</version>
     <vendor email="chris@hirvi.no" url="http://www.hirvi.no">Hirvi AS</vendor>
 
     <description><![CDATA[
@@ -10,6 +10,10 @@
 
     <change-notes><![CDATA[
     <html>
+        <b>Fixed in v0.1.10:</b>
+        <ul>
+            <li>Adding Javascript icon to ECMAScript files (`*.es6`, `*.es`)</li>
+        </ul>
         <b>Fixed in v0.1.9:</b>
         <ul>
             <li>Fails to launch when using Darker or Lighter theme. Thanks @robertfreund - #187</li>
@@ -41,6 +45,9 @@
     </change-notes>
 
     <idea-version since-build="122.519"/>
+    <!--Rubymine 2016.2-->
+    <idea-version since-build="162.1120.10"/>
+
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>

--- a/resources/icon_associations.xml
+++ b/resources/icon_associations.xml
@@ -71,7 +71,7 @@
         <regex name="XML" pattern=".*\.(xml|ini)$" icon="/icons/fileTypes/xml.png"/>
         <regex name="CSS" pattern=".*\.css$" icon="/icons/fileTypes/css.png"/>
         <regex name="JSON" pattern=".*\.json$" icon="/icons/fileTypes/json.png"/>
-        <regex name="Javascript" pattern=".*\.js$" icon="/icons/fileTypes/javaScript.png"/>
+        <regex name="Javascript" pattern=".*\.(js|es6|es)$" icon="/icons/fileTypes/javaScript.png"/>
         <regex name="Java Server Pages" pattern=".*\.jsp$" icon="/icons/fileTypes/jsp.png"/>
         <regex name="React JS" pattern=".*\.jsx$" icon="/icons/fileTypes/react.png"/>
         <regex name="Text" pattern=".*\.txt$" icon="/icons/fileTypes/text.png"/>


### PR DESCRIPTION
Hi,

I've updated the plugin to match latest Rubymine EAP version, and I've also added support for *.es6 and *.es files  to be grouped into Javascript icon files (If you have the time to design their own icon as well, that would be great :))

