### PR TITLE
Add missing color schemes for Ruby, Python, Django, ERB, and SASS

### DIFF
--- a/resources/colors/Material Theme - Darker.xml
+++ b/resources/colors/Material Theme - Darker.xml
@@ -581,6 +581,47 @@
                 <option name="FOREGROUND" value="798891" />
             </value>
         </option>
+        <option name="DJANGO_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="DJANGO_FILTER">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="DJANGO_ID">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="DJANGO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="DJANGO_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="DJANGO_STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_START_END">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
         <option name="DUPLICATE_FROM_SERVER">
             <value />
         </option>
@@ -1194,6 +1235,100 @@
                 <option name="FONT_TYPE" value="1" />
             </value>
         </option>
+        <option name="PY.BRACES">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.CLASS_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="PY.COMMA">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.DOT">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.FUNC_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="PY.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="PY.VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
         <option name="REST.FIXED">
             <value>
                 <option name="BACKGROUND" value="252b39" />
@@ -1209,14 +1344,285 @@
                 <option name="BACKGROUND" value="252b39" />
             </value>
         </option>
+        <option name="RHTML_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_END_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_START_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_OMIT_NEW_LINE_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_END_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_START_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="RUBY_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COLON">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COMMA">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="RUBY_CVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_DOT">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_EXPR_IN_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_GVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_HASH_ASSOC">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_INTERPOLATED_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="RUBY_IVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="RUBY_LINE_CONTINUATION">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_LOCAL_VAR_ID">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_METHOD_NAME">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
+        <option name="RUBY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="RUBY_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMETER_ID">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="RUBY_REGEXP">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_WORDS">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="SASS_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="4A4A4A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="SASS_DEFAULT">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_EXTEND">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
         <option name="SASS_IDENTIFIER">
             <value>
-                <option name="FOREGROUND" value="c2c8d7" />
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="SASS_IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
             </value>
         </option>
         <option name="SASS_MIXIN">
             <value>
-                <option name="FOREGROUND" value="c792ea" />
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="SASS_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="f07178" />
+            </value>
+        </option>
+        <option name="SASS_URL">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
             </value>
         </option>
         <option name="SEARCH_RESULT_ATTRIBUTES">

--- a/resources/colors/Material Theme - Default.xml
+++ b/resources/colors/Material Theme - Default.xml
@@ -1,2557 +1,1465 @@
-<scheme name="Material Theme (Modified)" parent_scheme="Default" version="1">
-  <option name="LINE_SPACING" value="1.0" />
-  <font>
-    <option name="EDITOR_FONT_SIZE" value="12" />
-    <option name="EDITOR_FONT_NAME" value="Menlo" />
-  </font>
-  <font>
-    <option name="EDITOR_FONT_NAME" value="Fira Code" />
-    <option name="EDITOR_FONT_SIZE" value="15" />
-  </font>
-  <font>
-    <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
-    <option name="EDITOR_FONT_SIZE" value="12" />
-  </font>
-  <option name="CONSOLE_FONT_NAME" value="Menlo" />
-  <option name="CONSOLE_FONT_SIZE" value="12" />
-  <colors>
-    <option name="ADDED_LINES_COLOR" value="212c32" />
-    <option name="ANNOTATIONS_COLOR" value="8b999f" />
-    <option name="BORDER_LINES_COLOR" value="" />
-    <option name="CARET_COLOR" value="FFCC00" />
-    <option name="CARET_ROW_COLOR" value="1a2226" />
-    <option name="CONSOLE_BACKGROUND_KEY" value="263238" />
-    <option name="DELETED_LINES_COLOR" value="f77669" />
-    <option name="DIFF_SEPARATORS_BACKGROUND" value="1e2a30" />
-    <option name="DIFF_SEPARATORS_TOP_BORDER" value="1b262b" />
-    <option name="FILESTATUS_ADDED" value="80cbc4" />
-    <option name="FILESTATUS_COPIED" value="659d9a" />
-    <option name="FILESTATUS_DELETED" value="f77669" />
-    <option name="FILESTATUS_HIJACKED" value="ffcb6b" />
-    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="f77669" />
-    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="546e7a" />
-    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-    <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="c3e88d" />
-    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="546e7a" />
-    <option name="FILESTATUS_MERGED" value="65738e" />
-    <option name="FILESTATUS_MODIFIED" value="80cbc4" />
-    <option name="FILESTATUS_NOT_CHANGED" value="" />
-    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80cbc4" />
-    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80cbc4" />
-    <option name="FILESTATUS_UNKNOWN" value="f77669" />
-    <option name="FILESTATUS_addedOutside" value="629755" />
-    <option name="FILESTATUS_changelistConflict" value="d5756c" />
-    <option name="FILESTATUS_modifiedOutside" value="80cbc4" />
-    <option name="GUTTER_BACKGROUND" value="263238" />
-    <option name="INDENT_GUIDE" value="65737e" />
-    <option name="LINE_NUMBERS_COLOR" value="eeffff" />
-    <option name="METHOD_SEPARATORS_COLOR" value="2e3c43" />
-    <option name="MODIFIED_LINES_COLOR" value="99b89d" />
-    <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
-    <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
-    <option name="RIGHT_MARGIN_COLOR" value="2e3c43" />
-    <option name="SELECTED_INDENT_GUIDE" value="65737e" />
-    <option name="SELECTED_TEARLINE_COLOR" value="99b89d" />
-    <option name="SELECTION_BACKGROUND" value="314549" />
-    <option name="SELECTION_FOREGROUND" value="" />
-    <option name="SOFT_WRAP_SIGN_COLOR" value="4f6269" />
-    <option name="TEARLINE_COLOR" value="3b4950" />
-    <option name="WHITESPACES" value="65737e" />
-    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="99b89d" />
-    <option name="DIFF_SEPARATORS_BACKGROUND" value="1E2A30"/>
-    <option name="DIFF_SEPARATORS_TOP_BORDER" value="1B262B"/>
-  </colors>
-  <attributes>
-    <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="d0d0ff" />
-      </value>
-    </option>
-    <option name="ANNOTATION_NAME_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fad430" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="BASH.CONDITIONAL">
-      <value>
-        <option name="FOREGROUND" value="2c9ea7" />
-      </value>
-    </option>
-    <option name="BASH.EXTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="e4cb8f" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="BASH.INTERNAL_COMMAND">
-      <value>
-        <option name="FOREGROUND" value="6dc2b8" />
-      </value>
-    </option>
-    <option name="BASH.VAR_DEF">
-      <value>
-        <option name="FOREGROUND" value="c2c8d7" />
-      </value>
-    </option>
-    <option name="BASH.VAR_USE">
-      <value>
-        <option name="FOREGROUND" value="ff5370" />
-      </value>
-    </option>
-    <option name="BLADE_DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="ff5370" />
-      </value>
-    </option>
-    <option name="BNF_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="1a1f29" />
-      </value>
-    </option>
-    <option name="BNF_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-      </value>
-    </option>
-    <option name="BREAKPOINT_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="743d3d" />
-      </value>
-    </option>
-    <option name="BUILDOUT.KEY">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="BUILDOUT.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="BUILDOUT.SECTION_NAME">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="BUILDOUT.VALUE">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="CLASS_NAME_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffcb6b" />
-      </value>
-    </option>
-    <option name="CLASS_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BOOLEAN">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BRACE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.BRACKET">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.CLASS_NAME">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.COLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.EXISTENTIAL">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.FUNCTION_BINDING">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.FUNCTION_NAME">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREDOC_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREDOC_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREGEX_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.HEREGEX_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="COFFEESCRIPT.IDENTIFIER" />
-    <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="dee3ec" />
-        <option name="EFFECT_TYPE" value="5" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.JAVASCRIPT_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="COFFEESCRIPT.IDENTIFIER" name="COFFEESCRIPT.LOCAL_VARIABLE" />
-    <option name="COFFEESCRIPT.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.OBJECT_KEY">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.OPERATIONS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.PARENTHESIS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.PROTOTYPE">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.RANGE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.SEMICOLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.SPLAT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="COFFEESCRIPT.THIS">
-      <value>
-        <option name="FOREGROUND" value="FF5370" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CONDITIONALLY_NOT_COMPILED">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CONSOLE_BLUE_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="CONSOLE_CYAN_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="06b8b8" />
-      </value>
-    </option>
-    <option name="CONSOLE_ERROR_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffb3b3" />
-      </value>
-    </option>
-    <option name="CONSOLE_GRAY_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="a7a7a7" />
-      </value>
-    </option>
-    <option name="CONSOLE_GREEN_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="68e868" />
-      </value>
-    </option>
-    <option name="CONSOLE_MAGENTA_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ff2eff" />
-      </value>
-    </option>
-    <option name="CONSOLE_NORMAL_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-      </value>
-    </option>
-    <option name="CONSOLE_RED_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ff6767" />
-      </value>
-    </option>
-    <option name="CONSOLE_SYSTEM_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="e4e4ff" />
-      </value>
-    </option>
-    <option name="CONSOLE_USER_INPUT">
-      <value>
-        <option name="FOREGROUND" value="6ae96a" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CONSOLE_YELLOW_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="754200" />
-      </value>
-    </option>
-    <option name="CSS.COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CSS.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="CSS.IDENT">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="CSS.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="CSS.PROPERTY_NAME">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="CSS.PROPERTY_VALUE">
-      <value>
-        <option name="FOREGROUND" value="68e868" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CSS.TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="CSS.URL">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="CTRL_CLICKABLE">
-      <value>
-        <option name="FOREGROUND" value="58bcb3" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="e3e3ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="71d7d7" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffc2c2" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="CUSTOM_NUMBER_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="CUSTOM_STRING_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="Clojure Atom">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="Clojure Character">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="Clojure Keyword">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="Clojure Line comment">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Clojure Literal">
-      <value>
-        <option name="FOREGROUND" value="FF5370" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Clojure Numbers">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="Clojure Strings">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="DEFAULT_ATTRIBUTE">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="DEFAULT_BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_BRACES">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_CLASS_NAME">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="DEFAULT_COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="f77669" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="DEFAULT_DOC_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_DOC_COMMENT_TAG">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_DOC_MARKUP">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_ENTITY">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="DEFAULT_FUNCTION_CALL">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_FUNCTION_DECLARATION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_GLOBAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="FF5370" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="DEFAULT_IDENTIFIER" />
-    <option name="DEFAULT_INSTANCE_FIELD">
-      <value>
-        <option name="FOREGROUND" value="52D1DC" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_INSTANCE_METHOD">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_INTERFACE_NAME">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="DEFAULT_INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="DEFAULT_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_LABEL" />
-    <option name="DEFAULT_LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_LOCAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_METADATA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="DEFAULT_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="F4E04D" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_PREDEFINED_SYMBOL">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="DEFAULT_SEMICOLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_STATIC_FIELD">
-      <value>
-        <option name="FOREGROUND" value="52D1DC" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DEFAULT_STATIC_METHOD">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="DEFAULT_TAG">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="BACKGROUND" value="263238" />
-        <option name="EFFECT_TYPE" value="5" />
-      </value>
-    </option>
-    <option name="DEFAULT_VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DEPRECATED_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="3" />
-        <option name="EFFECT_COLOR" value="c0c0c0" />
-      </value>
-    </option>
-    <option name="DIFF_CONFLICT">
-      <value>
-        <option name="BACKGROUND" value="763f34" />
-        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
-      </value>
-    </option>
-    <option name="DIFF_DELETED">
-      <value>
-        <option name="BACKGROUND" value="5b5b5b" />
-        <option name="ERROR_STRIPE_COLOR" value="747474" />
-      </value>
-    </option>
-    <option name="DIFF_INSERTED">
-      <value>
-        <option name="BACKGROUND" value="2f632f" />
-        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
-      </value>
-    </option>
-    <option name="DIFF_MODIFIED">
-      <value>
-        <option name="BACKGROUND" value="465983" />
-        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
-      </value>
-    </option>
-    <option name="DJANGO_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="DJANGO_FILTER">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="DJANGO_ID">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="DJANGO_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="DJANGO_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="DJANGO_STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="DJANGO_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DJANGO_TAG_START_END">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="DUPLICATE_FROM_SERVER">
-      <value>
-        <option name="BACKGROUND" value="30322b" />
-      </value>
-    </option>
-    <option name="ENUM_CONST">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="ERRORS_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="ff6767" />
-        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
-      </value>
-    </option>
-    <option name="EXECUTIONPOINT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="000101" />
-        <option name="BACKGROUND" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="FOLDED_TEXT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="3c3d3c" />
-        <option name="BACKGROUND" value="101010" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="3c3d3c" />
-      </value>
-    </option>
-    <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="BACKGROUND" value="161717" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="First symbol in list">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="GENERIC_SERVER_ERROR_OR_WARNING">
-      <value>
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="aa4e00" />
-        <option name="ERROR_STRIPE_COLOR" value="f49810" />
-      </value>
-    </option>
-    <option name="GHERKIN_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="GHERKIN_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="GHERKIN_OUTLINE_PARAMETER_SUBSTITUTION">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="GHERKIN_PYSTRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="GHERKIN_REGEXP_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_TABLE_CELL" />
-    <option name="GHERKIN_TABLE_HEADER_CELL">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="GHERKIN_TABLE_PIPE">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="GHERKIN_TAG">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="GHERKIN_TEXT" />
-    <option name="GQL_ID">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="GQL_INT_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="GQL_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="GQL_STRING_LITERAL">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="GROOVY_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-      </value>
-    </option>
-    <option name="GString">
-      <value>
-        <option name="FOREGROUND" value="6a8759" />
-      </value>
-    </option>
-    <option name="Groovydoc comment">
-      <value>
-        <option name="FOREGROUND" value="629755" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Groovydoc tag">
-      <value>
-        <option name="FOREGROUND" value="7cb36f" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="HAML_CLASS">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="HAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_FILTER" />
-    <option baseAttributes="HAML_TEXT" name="HAML_FILTER_CONTENT" />
-    <option name="HAML_ID">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_LINE_CONTINUATION" />
-    <option name="HAML_PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_CODE" />
-    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_START" />
-    <option name="HAML_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="HAML_STRING_INTERPOLATED">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="HAML_TAG">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="HAML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="HAML_TEXT" />
-    <option name="HAML_WS_REMOVAL">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="HAML_XHTML" />
-    <option name="HTML_ATTRIBUTE_NAME">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="HTML_ATTRIBUTE_VALUE">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="HTML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="HTML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="HTML_TAG">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="HTML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="HYPERLINK_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="c7c7ff" />
-      </value>
-    </option>
-    <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="3c3c57" />
-        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
-      </value>
-    </option>
-    <option name="IGNORE.VALUE">
-      <value>
-        <option name="FOREGROUND" value="c77554" />
-      </value>
-    </option>
-    <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-      </value>
-    </option>
-    <option name="INFO_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="333434" />
-        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
-      </value>
-    </option>
-    <option name="INJECTED_LANGUAGE_FRAGMENT">
-      <value>
-        <option name="BACKGROUND" value="273627" />
-      </value>
-    </option>
-    <option name="INSTANCE_FIELD_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="INTERFACE_NAME_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c3e88d" />
-      </value>
-    </option>
-    <option name="IVAR">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="JADE_FILE_PATH">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option baseAttributes="DEFAULT_LABEL" name="JADE_FILTER_NAME" />
-    <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK" />
-    <option name="JADE_STATEMENTS">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="JAVA_BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JAVA_BRACES">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_DOC_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JAVA_DOC_MARKUP">
-      <value>
-        <option name="BACKGROUND" value="223f22" />
-      </value>
-    </option>
-    <option name="JAVA_DOC_TAG">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="80807f" />
-      </value>
-    </option>
-    <option name="JAVA_DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="JAVA_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="JAVA_LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JAVA_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="JAVA_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_PARENTH">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_SEMICOLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JAVA_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="JAVA_VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JFLEX_MACROS_REF">
-      <value>
-        <option name="FOREGROUND" value="1a1f29" />
-      </value>
-    </option>
-    <option name="JS.GLOBAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="FF5370" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JS.INSTANCE_MEMBER_FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="JS.INSTANCE_MEMBER_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="52D1DC" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JS.LOCAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="EEFFFF" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JS.PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="F4E04D" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="JS.REGEXP">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="JSON.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="f55e53" />
-      </value>
-    </option>
-    <option name="JSON.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="b7e876" />
-      </value>
-    </option>
-    <option name="JSON.PROPERTY_KEY">
-      <value>
-        <option name="FOREGROUND" value="b7e876" />
-      </value>
-    </option>
-    <option name="JSON.STRING">
-      <value>
-        <option name="FOREGROUND" value="b7e876" />
-      </value>
-    </option>
-    <option name="JSON.VALID_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="6dc2b8" />
-      </value>
-    </option>
-    <option name="JSP_DIRECTIVE_NAME">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="JSP_SCRIPTING_BACKGROUND">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-      </value>
-    </option>
-    <option name="KOTLIN_ANNOTATION">
-      <value />
-    </option>
-    <option name="KOTLIN_IMPLICIT_EXHAUSTIVE_WHEN">
-      <value />
-    </option>
-    <option name="KOTLIN_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="c792ea" />
-      </value>
-    </option>
-    <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
-      <value />
-    </option>
-    <option name="KOTLIN_SMART_CAST_RECEIVER">
-      <value />
-    </option>
-    <option name="KOTLIN_SMART_CAST_VALUE">
-      <value />
-    </option>
-    <option name="KOTLIN_SMART_CONSTANT">
-      <value />
-    </option>
-    <option name="LABEL">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="LESS_INJECTED_CODE" />
-    <option baseAttributes="TEXT" name="LESS_JS_CODE_DELIM" />
-    <option name="LESS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="LINE_FULL_COVERAGE">
-      <value>
-        <option name="BACKGROUND" value="1fc700" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="LINE_NONE_COVERAGE">
-      <value>
-        <option name="BACKGROUND" value="ab1c07" />
-        <option name="FONT_TYPE" value="1" />
-        <option name="EFFECT_TYPE" value="3" />
-      </value>
-    </option>
-    <option name="LINE_PARTIAL_COVERAGE">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="LOCAL_VARIABLE_ATTRIBUTES" />
-    <option name="MACRONAME">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="LOG_ERROR_OUTPUT">
-      <value>
-        <option name="FOREGROUND" value="ff6b68" />
-      </value>
-    </option>
-    <option name="List/map to object conversion">
-      <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="MACRO_PARAMETER" />
-    <option name="MACRONAME">
-      <value>
-        <option name="FOREGROUND" value="908b25" />
-      </value>
-    </option>
-    <option name="MAGIC_MEMBER_ACCESS">
-      <value>
-        <option name="FOREGROUND" value="20c5c3" />
-      </value>
-    </option>
-    <option name="MARKDOWN.AUTO_LINK">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.BULLET_LIST">
-      <value>
-        <option name="FOREGROUND" value="646877" />
-      </value>
-    </option>
-    <option name="MARKDOWN.EXPLICIT_LINK">
-      <value>
-        <option name="FOREGROUND" value="6dc2b8" />
-      </value>
-    </option>
-    <option name="MARKDOWN.HEADER_LEVEL_1">
-      <value>
-        <option name="FOREGROUND" value="63c0ee" />
-      </value>
-    </option>
-    <option name="MARKDOWN.HEADER_LEVEL_2">
-      <value>
-        <option name="FOREGROUND" value="63c0ee" />
-      </value>
-    </option>
-    <option name="MARKDOWN.HEADER_LEVEL_3">
-      <value>
-        <option name="FOREGROUND" value="63c0ee" />
-      </value>
-    </option>
-    <option name="MARKDOWN.HEADER_LEVEL_4">
-      <value>
-        <option name="FOREGROUND" value="63c0ee" />
-      </value>
-    </option>
-    <option name="MARKDOWN.HEADER_LEVEL_5">
-      <value>
-        <option name="FOREGROUND" value="63c0ee" />
-      </value>
-    </option>
-    <option name="MARKDOWN.IMAGE">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.MAIL_LINK">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.REFERENCE_IMAGE">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.REFERENCE_LINK">
-      <value>
-        <option name="FOREGROUND" value="ff355b" />
-      </value>
-    </option>
-    <option name="MARKDOWN.TEXT">
-      <value>
-        <option name="FOREGROUND" value="c3cee3" />
-      </value>
-    </option>
-    <option name="MATCHED_BRACE_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="3a6da0" />
-      </value>
-    </option>
-    <option name="MESSAGE_ARGUMENT">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="NOT_USED_ELEMENT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="80807f" />
-      </value>
-    </option>
-    <option name="OC.BADCHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="OC.BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.BRACES" />
-    <option baseAttributes="OC.DOT" name="OC.BRACKETS" />
-    <option baseAttributes="OC.DOT" name="OC.COMMA" />
-    <option name="OC.CPP_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="OC.DIRECTIVE">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="OC.DOT" />
-    <option name="OC.EXTERN_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="OC.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="OC.FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="OC.GLOBAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="OC.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="OC.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="OC.LOCAL_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="OC.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.OPERATION_SIGN" />
-    <option name="OC.PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.PARENTHS" />
-    <option name="OC.PROPERTY">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="OC.SELFSUPERTHIS">
-      <value>
-        <option name="FOREGROUND" value="FF5370" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option baseAttributes="OC.DOT" name="OC.SEMICOLON" />
-    <option name="OC.STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="OC.STRUCT_FIELD">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="OC_FORMAT_TOKEN">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="PARAMETER_ATTRIBUTES" />
-    <option name="PHP_CLASS">
-      <value>
-        <option name="FOREGROUND" value="ffcb6b" />
-      </value>
-    </option>
-    <option name="PHP_EXEC_COMMAND_ID">
-      <value>
-        <option name="FOREGROUND" value="a5c25c" />
-        <option name="BACKGROUND" value="252b39" />
-      </value>
-    </option>
-    <option name="PHP_HEREDOC_ID">
-      <value>
-        <option name="FOREGROUND" value="2c9ea7" />
-      </value>
-    </option>
-    <option name="PHP_PARAMETER">
-      <value>
-        <option name="FOREGROUND" value="ff5370" />
-      </value>
-    </option>
-    <option name="PHP_TAG">
-      <value>
-        <option name="FOREGROUND" value="be2c23" />
-      </value>
-    </option>
-    <option name="PHP_VAR">
-      <value>
-        <option name="FOREGROUND" value="ff5370" />
-      </value>
-    </option>
-    <option name="PROPERTIES.INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-        <option name="BACKGROUND" value="252b39" />
-        <option name="EFFECT_COLOR" value="ff0000" />
-        <option name="EFFECT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="PROPERTIES.KEY">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
-      <value>
-        <option name="FOREGROUND" value="c3cee3" />
-      </value>
-    </option>
-    <option name="PROPERTIES.VALUE">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-      </value>
-    </option>
-    <option name="PROTOCOL_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="PUPPET_BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="PUPPET_BLOCK_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="PUPPET_BRACES">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_CLASS">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="PUPPET_COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_ESCAPE_SEQUENCE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="PUPPET_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="PUPPET_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_PARENTH">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_REGEX">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="PUPPET_RESOURCE_REFERENCE" />
-    <option name="PUPPET_SEMICOLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_SQ_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="PUPPET_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="PUPPET_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PUPPET_VARIABLE_INTERPOLATION">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="PY.BRACES">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PY.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PY.BUILTIN_NAME">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="PY.CLASS_DEFINITION">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="PY.COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PY.DECORATOR">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="PY.DOC_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="PY.DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PY.FUNC_DEFINITION">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="PY.INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="PY.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="PY.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="PY.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="PY.OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="PY.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
-    <option name="PY.PREDEFINED_USAGE">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="PY.STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="PY.VALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACES">
-      <value>
-        <option name="FOREGROUND" value="2c9ea7" />
-      </value>
-    </option>
-    <option name="REGEXP.BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="c792ea" />
-      </value>
-    </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="6dc2b8" />
-      </value>
-    </option>
-    <option name="REGEXP.ESC_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="c792ea" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.INVALID_STRING_ESCAPE">
-      <value>
-        <option name="FOREGROUND" value="6dc2b8" />
-        <option name="EFFECT_COLOR" value="bc3f3c" />
-        <option name="EFFECT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="REGEXP.META">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REGEXP.PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="798194" />
-      </value>
-    </option>
-    <option name="REGEXP.QUOTE_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.BOLD">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="REST.EXPLICIT">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="REST.FIELD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="REST.FIXED">
-      <value>
-        <option name="BACKGROUND" value="48485f" />
-      </value>
-    </option>
-    <option name="REST.INLINE">
-      <value>
-        <option name="BACKGROUND" value="273627" />
-      </value>
-    </option>
-    <option name="REST.INTERPRETED">
-      <value>
-        <option name="BACKGROUND" value="4d5d3d" />
-      </value>
-    </option>
-    <option name="REST.ITALIC">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="REST.LINE_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="REST.REF.NAME">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="REST.SECTION.HEADER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="RHTML_COMMENT_ID">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="RHTML_EXPRESSION_END_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RHTML_EXPRESSION_START_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RHTML_OMIT_NEW_LINE_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RHTML_SCRIPTING_BACKGROUND_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RHTML_SCRIPTLET_END_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RHTML_SCRIPTLET_START_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="RUBY_BRACKETS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_COLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_COMMA">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="RUBY_CONSTANT">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="RUBY_CONSTANT_DECLARATION">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="RUBY_CVAR">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="RUBY_DOT">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_ESCAPE_SEQUENCE">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_EXPR_IN_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="RUBY_GVAR">
-      <value>
-        <option name="FOREGROUND" value="ff5470" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="RUBY_HASH_ASSOC">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_HEREDOC_CONTENT">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="RUBY_HEREDOC_ID">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_IDENTIFIER">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="RUBY_INTERPOLATED_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option name="RUBY_IVAR">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="RUBY_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="RUBY_LINE_CONTINUATION">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_LOCAL_VAR_ID">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="RUBY_METHOD_NAME">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
-    <option name="RUBY_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="RUBY_OPERATION_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_PARAMDEF_CALL">
-      <value>
-        <option name="FOREGROUND" value="82AAFF" />
-      </value>
-    </option>
-    <option name="RUBY_PARAMETER_ID">
-      <value>
-        <option name="FOREGROUND" value="f4e04d" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="RUBY_REGEXP">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_SEMICOLON">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="RUBY_SPECIFIC_CALL">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-      </value>
-    </option>
-    <option name="RUBY_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="RUBY_SYMBOL">
-      <value>
-        <option name="FOREGROUND" value="52D1DC" />
-      </value>
-    </option>
-    <option name="RUBY_WORDS">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="SASS_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SASS_DEFAULT">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SASS_EXTEND">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SASS_FUNCTION">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="SASS_IDENTIFIER">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="SASS_IMPORTANT">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SASS_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SASS_MIXIN">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SASS_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="SASS_PROPERTY_NAME">
-      <value>
-        <option name="FOREGROUND" value="FFCB6B" />
-      </value>
-    </option>
-    <option name="SASS_PROPERTY_VALUE">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="SASS_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="SASS_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="SASS_URL">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="SASS_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="SEARCH_RESULT_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="4f4f82" />
-      </value>
-    </option>
-    <option name="SLIM_BAD_CHARACTER">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="BACKGROUND" value="FF5370" />
-      </value>
-    </option>
-    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_CALL" />
-    <option name="SLIM_CLASS">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="SLIM_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="SLIM_DOCTYPE_KWD">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="SLIM_FILTER">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_FILTER_CONTENT" />
-    <option name="SLIM_ID">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="SLIM_INTERPOLATION">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="SLIM_PARENTHS">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option baseAttributes="HAML_TEXT" name="SLIM_RUBY_CODE" />
-    <option baseAttributes="TEXT" name="SLIM_STATIC_CONTENT" />
-    <option name="SLIM_STRING_INTERPOLATED">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="SLIM_TAG">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="SLIM_TAG_ATTR_KEY">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="SLIM_TAG_START">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="SPY-JS.EXCEPTION">
-      <value>
-        <option name="BACKGROUND" value="713f3f" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-      </value>
-    </option>
-    <option name="SPY-JS.FUNCTION_SCOPE">
-      <value>
-        <option name="BACKGROUND" value="2e2e20" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-      </value>
-    </option>
-    <option name="SPY-JS.PATH_LEVEL_ONE">
-      <value>
-        <option name="BACKGROUND" value="264226" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-      </value>
-    </option>
-    <option name="SPY-JS.PATH_LEVEL_TWO">
-      <value>
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-      </value>
-    </option>
-    <option name="SPY-JS.PROGRAM_SCOPE">
-      <value>
-        <option name="BACKGROUND" value="2b2b2b" />
-        <option name="EFFECT_TYPE" value="2" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-      </value>
-    </option>
-    <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
-    <option name="STATIC_FIELD_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="fda5ff" />
-        <option name="FONT_TYPE" value="3" />
-      </value>
-    </option>
-    <option name="SQL_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="SQL_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="f25619" />
-      </value>
-    </option>
-    <option name="SQL_STRING">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="SQL_SYNTHETIC_ENTITY">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-      </value>
-    </option>
-    <option name="STATIC_FIELD_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="f77669" />
-        <option name="FONT_TYPE" value="2" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="STATIC_METHOD_ATTRIBUTES">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="Static property reference ID">
-      <value>
-        <option name="FOREGROUND" value="1a1f29" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="TAG_ATTR_KEY">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="TAPESTRY_COMPONENT_TAG">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="bd92ea" />
-      </value>
-    </option>
-    <option name="TEXT">
-      <value>
-        <option name="FOREGROUND" value="eeffff" />
-        <option name="BACKGROUND" value="263238" />
-      </value>
-    </option>
-    <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="5f5f00" />
-        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
-      </value>
-    </option>
-    <option name="TODO_DEFAULT_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="c7c7ff" />
-        <option name="FONT_TYPE" value="3" />
-        <option name="ERROR_STRIPE_COLOR" value="ff" />
-      </value>
-    </option>
-    <option name="TYPEDEF">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="ffffff" />
-      </value>
-    </option>
-    <option name="TYPO">
-      <value>
-        <option name="EFFECT_COLOR" value="ffeb95" />
-        <option name="EFFECT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="UNMATCHED_BRACE_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="583535" />
-      </value>
-    </option>
-    <option name="Unresolved reference access">
-      <value>
-        <option name="FOREGROUND" value="808080" />
-        <option name="EFFECT_COLOR" value="808080" />
-        <option name="EFFECT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="VELOCITY_KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="VELOCITY_NUMBER">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-      </value>
-    </option>
-    <option name="VELOCITY_SCRIPTING_BACKGROUND">
-      <value>
-        <option name="BACKGROUND" value="252b39" />
-      </value>
-    </option>
-    <option name="Valid string escape">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-      </value>
-    </option>
-    <option name="WARNING_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="4a3f10" />
-        <option name="EFFECT_TYPE" value="1" />
-        <option name="EFFECT_COLOR" value="eeffff" />
-        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
-      </value>
-    </option>
-    <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="472c47" />
-        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
-      </value>
-    </option>
-    <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
-      <value>
-        <option name="BACKGROUND" value="623062" />
-      </value>
-    </option>
-    <option name="WRONG_REFERENCES_ATTRIBUTES">
-      <value>
-        <option name="FOREGROUND" value="bc3f3c" />
-      </value>
-    </option>
-    <option name="XML_ATTRIBUTE_NAME">
-      <value>
-        <option name="FOREGROUND" value="C792EA" />
-      </value>
-    </option>
-    <option name="XML_ATTRIBUTE_VALUE">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="XML_ENTITY_REFERENCE">
-      <value>
-        <option name="FOREGROUND" value="F78C6C" />
-      </value>
-    </option>
-    <option name="XML_PROLOGUE">
-      <value>
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="XML_TAG">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="XML_TAG_DATA">
-      <value>
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="XML_TAG_NAME">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="XPATH.KEYWORD">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="XPATH.NUMBER">
-      <value>
-        <option name="FOREGROUND" value="f25619" />
-      </value>
-    </option>
-    <option name="XPATH.STRING">
-      <value>
-        <option name="FOREGROUND" value="f36e3a" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="XPATH.XPATH_VARIABLE">
-      <value>
-        <option name="FOREGROUND" value="f38630" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-    <option name="YAML_COMMENT">
-      <value>
-        <option name="FOREGROUND" value="546E7A" />
-        <option name="FONT_TYPE" value="2" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_DSTRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_KEY">
-      <value>
-        <option name="FOREGROUND" value="f07178" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_LIST">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_STRING">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="YAML_SCALAR_VALUE">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="YAML_SIGN">
-      <value>
-        <option name="FOREGROUND" value="89DDFF" />
-      </value>
-    </option>
-    <option name="YAML_TEXT">
-      <value>
-        <option name="FOREGROUND" value="C3E88D" />
-      </value>
-    </option>
-    <option name="osmorc.headerName">
-      <value>
-        <option name="FOREGROUND" value="a7dbd8" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
-  </attributes>
+<scheme name="Material Theme - Default" version="142" parent_scheme="Default">
+    <option name="LINE_SPACING" value="1.6" />
+    <font>
+        <option name="EDITOR_FONT_NAME" value="Fira Code" />
+        <option name="EDITOR_FONT_SIZE" value="15" />
+    </font>
+    <font>
+        <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
+        <option name="EDITOR_FONT_SIZE" value="12" />
+    </font>
+    <option name="CONSOLE_FONT_NAME" value="Menlo" />
+    <option name="CONSOLE_FONT_SIZE" value="12" />
+    <colors>
+        <option name="ADDED_LINES_COLOR" value="212c32" />
+        <option name="ANNOTATIONS_COLOR" value="8b999f" />
+        <option name="BORDER_LINES_COLOR" value="" />
+        <option name="CARET_COLOR" value="ffcc00" />
+        <option name="CARET_ROW_COLOR" value="222f35" />
+        <option name="CONSOLE_BACKGROUND_KEY" value="263238" />
+        <option name="DELETED_LINES_COLOR" value="f77669" />
+        <option name="DIFF_SEPARATORS_BACKGROUND" value="1e2a30" />
+        <option name="DIFF_SEPARATORS_TOP_BORDER" value="1b262b" />
+        <option name="FILESTATUS_ADDED" value="80cbc4" />
+        <option name="FILESTATUS_COPIED" value="659d9a" />
+        <option name="FILESTATUS_DELETED" value="f77669" />
+        <option name="FILESTATUS_HIJACKED" value="ffcb6b" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="f77669" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="546e7a" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
+        <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="c3e88d" />
+        <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="546e7a" />
+        <option name="FILESTATUS_MERGED" value="65738e" />
+        <option name="FILESTATUS_MODIFIED" value="80cbc4" />
+        <option name="FILESTATUS_NOT_CHANGED" value="" />
+        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80cbc4" />
+        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80cbc4" />
+        <option name="FILESTATUS_UNKNOWN" value="f77669" />
+        <option name="FILESTATUS_addedOutside" value="629755" />
+        <option name="FILESTATUS_changelistConflict" value="d5756c" />
+        <option name="FILESTATUS_modifiedOutside" value="80cbc4" />
+        <option name="GUTTER_BACKGROUND" value="263238" />
+        <option name="INDENT_GUIDE" value="" />
+        <option name="LINE_NUMBERS_COLOR" value="475f63" />
+        <option name="METHOD_SEPARATORS_COLOR" value="2e3c43" />
+        <option name="MODIFIED_LINES_COLOR" value="99b89d" />
+        <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
+        <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
+        <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+        <option name="RIGHT_MARGIN_COLOR" value="2e3c43" />
+        <option name="SELECTED_INDENT_GUIDE" value="505050" />
+        <option name="SELECTED_TEARLINE_COLOR" value="99b89d" />
+        <option name="SELECTION_BACKGROUND" value="314549" />
+        <option name="SELECTION_FOREGROUND" value="" />
+        <option name="SOFT_WRAP_SIGN_COLOR" value="4f6269" />
+        <option name="TEARLINE_COLOR" value="3b4950" />
+        <option name="WHITESPACES" value="2e3c43" />
+        <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="99b89d" />
+        <option name="DIFF_SEPARATORS_BACKGROUND" value="1E2A30"/>
+        <option name="DIFF_SEPARATORS_TOP_BORDER" value="1B262B"/>
+    </colors>
+    <attributes>
+        <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="d0d0ff" />
+            </value>
+        </option>
+        <option name="ANNOTATION_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="fad430" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="ff5370" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="BASH.CONDITIONAL">
+            <value>
+                <option name="FOREGROUND" value="2c9ea7" />
+            </value>
+        </option>
+        <option name="BASH.EXTERNAL_COMMAND">
+            <value>
+                <option name="FOREGROUND" value="e4cb8f" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="BASH.INTERNAL_COMMAND">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="BASH.VAR_DEF">
+            <value>
+                <option name="FOREGROUND" value="c2c8d7" />
+            </value>
+        </option>
+        <option name="BASH.VAR_USE">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="BLADE_DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="BNF_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="1a1f29" />
+            </value>
+        </option>
+        <option name="BNF_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="BREAKPOINT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="CLASS_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffcb6b" />
+            </value>
+        </option>
+        <option name="CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="1a1f29" />
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
+            <value>
+                <option name="FOREGROUND" value="dee3ec" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="dee3ec" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.PARAMETER">
+            <value>
+                <option name="EFFECT_COLOR" value="dee3ec" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="CONDITIONALLY_NOT_COMPILED">
+            <value>
+                <option name="FOREGROUND" value="536c46" />
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="7eaef1" />
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="5394ec" />
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="6cdada" />
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="33cccc" />
+            </value>
+        </option>
+        <option name="CONSOLE_ERROR_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff6b68" />
+            </value>
+        </option>
+        <option name="CONSOLE_GRAY_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="999999" />
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="70ff70" />
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="7f00" />
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff99ff" />
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff70ff" />
+            </value>
+        </option>
+        <option name="CONSOLE_NORMAL_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+            </value>
+        </option>
+        <option name="CONSOLE_OUTPUT">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="CONSOLE_RANGE_TO_EXECUTE">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="CONSOLE_RED_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff8785" />
+            </value>
+        </option>
+        <option name="CONSOLE_RED_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff6b68" />
+            </value>
+        </option>
+        <option name="CONSOLE_SYSTEM_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="f8f8f0" />
+            </value>
+        </option>
+        <option name="CONSOLE_WHITE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="f8f8f0" />
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffff00" />
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="cdcd00" />
+            </value>
+        </option>
+        <option name="CSS.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="CSS.COLOR">
+            <value>
+                <option name="FOREGROUND" value="ffea7d" />
+            </value>
+        </option>
+        <option name="CSS.DOT">
+            <value>
+                <option name="FOREGROUND" value="ffc251" />
+            </value>
+        </option>
+        <option name="CSS.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="CSS.HASH">
+            <value>
+                <option name="FOREGROUND" value="f9cf0a" />
+            </value>
+        </option>
+        <option name="CSS.IDENT">
+            <value>
+                <option name="FOREGROUND" value="ffc251" />
+            </value>
+        </option>
+        <option name="CSS.IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="CSS.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f55e53" />
+            </value>
+        </option>
+        <option name="CSS.OPERATORS">
+            <value>
+                <option name="FOREGROUND" value="f55e53" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="CSS.PARENTHESES">
+            <value>
+                <option name="FOREGROUND" value="c2c8d7" />
+            </value>
+        </option>
+        <option name="CSS.PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="CSS.PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="c3cee3" />
+            </value>
+        </option>
+        <option name="CSS.PSEUDO">
+            <value>
+                <option name="FOREGROUND" value="ffc251" />
+            </value>
+        </option>
+        <option name="CSS.TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="CSS.UNICODE.RANGE">
+            <value>
+                <option name="FOREGROUND" value="f55e53" />
+            </value>
+        </option>
+        <option name="CSS.URL">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="CTRL_CLICKABLE">
+            <value>
+                <option name="FOREGROUND" value="58bcb3" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="8000" />
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="82b1ff" />
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ab51ba" />
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f9795" />
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="CUSTOM_NUMBER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="CUSTOM_STRING_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="6a8759" />
+            </value>
+        </option>
+        <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="4646f1" />
+            </value>
+        </option>
+        <option name="DEFAULT_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="DEFAULT_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546e7a" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="DEFAULT_BRACES">
+            <value>
+                <option name="FOREGROUND" value="cad3de" />
+            </value>
+        </option>
+        <option name="DEFAULT_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="cad3de" />
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffcb6b" />
+            </value>
+        </option>
+        <option name="DEFAULT_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546e7a" />
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+            <value>
+                <option name="FOREGROUND" value="546e7a" />
+                <option name="FONT_TYPE" value="3" />
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_MARKUP">
+            <value>
+                <option name="FOREGROUND" value="546e7a" />
+            </value>
+        </option>
+        <option name="DEFAULT_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="82b1ff" />
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="82b1ff" />
+            </value>
+        </option>
+        <option name="DEFAULT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="c3d3de" />
+            </value>
+        </option>
+        <option name="DEFAULT_INSTANCE_FIELD">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="DEFAULT_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="EFFECT_COLOR" value="ff5370" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="DEFAULT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="DEFAULT_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546e7a" />
+            </value>
+        </option>
+        <option name="DEFAULT_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="92bdec" />
+            </value>
+        </option>
+        <option name="DEFAULT_METADATA">
+            <value>
+                <option name="FOREGROUND" value="bbb529" />
+            </value>
+        </option>
+        <option name="DEFAULT_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+            </value>
+        </option>
+        <option name="DEFAULT_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="80cbc4" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="DEFAULT_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="DEFAULT_PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="798194" />
+            </value>
+        </option>
+        <option name="DEFAULT_PREDEFINED_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="58bcb3" />
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_FIELD">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_METHOD">
+            <value>
+                <option name="FOREGROUND" value="8dc4f0" />
+            </value>
+        </option>
+        <option name="DEFAULT_STRING">
+            <value>
+                <option name="FOREGROUND" value="c3e887" />
+            </value>
+        </option>
+        <option name="DEFAULT_TAG">
+            <value />
+        </option>
+        <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="BACKGROUND" value="263238" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
+        <option name="DEFAULT_VALID_STRING_ESCAPE">
+            <value />
+        </option>
+        <option name="DELETED_TEXT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+                <option name="EFFECT_COLOR" value="c14360" />
+                <option name="EFFECT_TYPE" value="3" />
+            </value>
+        </option>
+        <option name="DEPRECATED_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="d3423e" />
+                <option name="EFFECT_TYPE" value="3" />
+            </value>
+        </option>
+        <option name="DIFF_CONFLICT">
+            <value>
+                <option name="BACKGROUND" value="b03435" />
+                <option name="ERROR_STRIPE_COLOR" value="b03435" />
+            </value>
+        </option>
+        <option name="DIFF_DELETED">
+            <value>
+                <option name="BACKGROUND" value="656e76" />
+                <option name="ERROR_STRIPE_COLOR" value="656e76" />
+            </value>
+        </option>
+        <option name="DIFF_INSERTED">
+            <value>
+                <option name="BACKGROUND" value="447152" />
+                <option name="ERROR_STRIPE_COLOR" value="447152" />
+            </value>
+        </option>
+        <option name="DIFF_MODIFIED">
+            <value>
+                <option name="BACKGROUND" value="43698d" />
+                <option name="ERROR_STRIPE_COLOR" value="43698d" />
+            </value>
+        </option>
+        <option name="DOC_COMMENT_TAG_VALUE">
+            <value>
+                <option name="FOREGROUND" value="798891" />
+            </value>
+        </option>
+        <option name="DUPLICATE_FROM_SERVER">
+            <value />
+        </option>
+        <option name="ENUM_CONST">
+            <value>
+                <option name="FOREGROUND" value="9373a5" />
+            </value>
+        </option>
+        <option name="ERRORS_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="ff5370" />
+                <option name="ERROR_STRIPE_COLOR" value="b23e56" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="EXECUTIONPOINT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="FOLDED_TEXT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f3f349" />
+            </value>
+        </option>
+        <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="80cbc4" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+            <value>
+                <option name="EFFECT_COLOR" value="f49810" />
+                <option name="ERROR_STRIPE_COLOR" value="f49810" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="GROOVY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="GString">
+            <value>
+                <option name="FOREGROUND" value="6a8759" />
+            </value>
+        </option>
+        <option name="Groovydoc comment">
+            <value>
+                <option name="FOREGROUND" value="629755" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="Groovydoc tag">
+            <value>
+                <option name="FOREGROUND" value="7cb36f" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="HAML_RUBY_CODE">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="HAML_TAG">
+            <value>
+                <option name="FOREGROUND" value="c3cee3" />
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffcb6b" />
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="c3e887" />
+            </value>
+        </option>
+        <option name="HTML_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="505c63" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="HTML_ENTITY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="92bdec" />
+            </value>
+        </option>
+        <option name="HTML_TAG">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="58bcb3" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="34434a" />
+                <option name="ERROR_STRIPE_COLOR" value="4d6168" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.VALUE">
+            <value>
+                <option name="FOREGROUND" value="c77554" />
+            </value>
+        </option>
+        <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="b389c5" />
+                <option name="EFFECT_COLOR" value="b389c5" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="INFO_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="d9b2d5" />
+                <option name="ERROR_STRIPE_COLOR" value="aeae80" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="INJECTED_LANGUAGE_FRAGMENT">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+            </value>
+        </option>
+        <option name="INSTANCE_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="INTERFACE_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="c3e88d" />
+            </value>
+        </option>
+        <option name="IVAR">
+            <value>
+                <option name="FOREGROUND" value="9373a5" />
+            </value>
+        </option>
+        <option name="Instance field">
+            <value />
+        </option>
+        <option name="Instance property reference ID" baseAttributes="INSTANCE_FIELD_ATTRIBUTES" />
+        <option name="JAVA_COMMA">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="JAVA_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="505c63" />
+            </value>
+        </option>
+        <option name="JAVA_DOC_TAG">
+            <value>
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="JAVA_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="JAVA_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+            </value>
+        </option>
+        <option name="JAVA_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="JAVA_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="JFLEX_MACROS_REF">
+            <value>
+                <option name="FOREGROUND" value="1a1f29" />
+            </value>
+        </option>
+        <option name="JS.GLOBAL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+            </value>
+        </option>
+        <option name="JS.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="c3e887" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="JS.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+            </value>
+        </option>
+        <option name="JS.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="d0f5d4" />
+            </value>
+        </option>
+        <option name="JS.REGEXP">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JS.VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JSON.INVALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="e74552" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="JSON.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="f55e53" />
+            </value>
+        </option>
+        <option name="JSON.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="b7e876" />
+            </value>
+        </option>
+        <option name="JSON.PROPERTY_KEY">
+            <value>
+                <option name="FOREGROUND" value="b7e876" />
+            </value>
+        </option>
+        <option name="JSON.STRING">
+            <value>
+                <option name="FOREGROUND" value="b7e876" />
+            </value>
+        </option>
+        <option name="JSON.VALID_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="JSP_DIRECTIVE_NAME">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="JSP_SCRIPTING_BACKGROUND">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="KOTLIN_ANNOTATION">
+            <value />
+        </option>
+        <option name="KOTLIN_IMPLICIT_EXHAUSTIVE_WHEN">
+            <value />
+        </option>
+        <option name="KOTLIN_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
+            <value />
+        </option>
+        <option name="KOTLIN_SMART_CAST_RECEIVER">
+            <value />
+        </option>
+        <option name="KOTLIN_SMART_CAST_VALUE">
+            <value />
+        </option>
+        <option name="KOTLIN_SMART_CONSTANT">
+            <value />
+        </option>
+        <option name="LABEL">
+            <value>
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="LINE_FULL_COVERAGE">
+            <value>
+                <option name="BACKGROUND" value="1fc700" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="LINE_NONE_COVERAGE">
+            <value>
+                <option name="BACKGROUND" value="ab1c07" />
+                <option name="FONT_TYPE" value="1" />
+                <option name="EFFECT_TYPE" value="3" />
+            </value>
+        </option>
+        <option name="LINE_PARTIAL_COVERAGE">
+            <value>
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="LOG_ERROR_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff6b68" />
+            </value>
+        </option>
+        <option name="List/map to object conversion">
+            <value>
+                <option name="FOREGROUND" value="e8bf6a" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="MACRONAME">
+            <value>
+                <option name="FOREGROUND" value="908b25" />
+            </value>
+        </option>
+        <option name="MAGIC_MEMBER_ACCESS">
+            <value>
+                <option name="FOREGROUND" value="20c5c3" />
+            </value>
+        </option>
+        <option name="MARKDOWN.AUTO_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.BULLET_LIST">
+            <value>
+                <option name="FOREGROUND" value="646877" />
+            </value>
+        </option>
+        <option name="MARKDOWN.EXPLICIT_LINK">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_1">
+            <value>
+                <option name="FOREGROUND" value="63c0ee" />
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_2">
+            <value>
+                <option name="FOREGROUND" value="63c0ee" />
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_3">
+            <value>
+                <option name="FOREGROUND" value="63c0ee" />
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_4">
+            <value>
+                <option name="FOREGROUND" value="63c0ee" />
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_5">
+            <value>
+                <option name="FOREGROUND" value="63c0ee" />
+            </value>
+        </option>
+        <option name="MARKDOWN.IMAGE">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.MAIL_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE_IMAGE">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="MARKDOWN.TEXT">
+            <value>
+                <option name="FOREGROUND" value="c3cee3" />
+            </value>
+        </option>
+        <option name="MATCHED_BRACE_ATTRIBUTES">
+            <value>
+                <option name="FONT_TYPE" value="1" />
+                <option name="EFFECT_COLOR" value="b39613" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="MESSAGE_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="c4b3a3" />
+            </value>
+        </option>
+        <option name="METHOD_DECLARATION_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="82b1ff" />
+            </value>
+        </option>
+        <option name="NOT_USED_ELEMENT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="808080" />
+                <option name="EFFECT_COLOR" value="808080" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="Number">
+            <value>
+                <option name="FOREGROUND" value="f25619" />
+            </value>
+        </option>
+        <option name="OC.CPP_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="OC.DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="80b000" />
+            </value>
+        </option>
+        <option name="OC.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="OC.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f25619" />
+            </value>
+        </option>
+        <option name="OC.PROPERTY">
+            <value>
+                <option name="FOREGROUND" value="cdbcac" />
+            </value>
+        </option>
+        <option name="OC.SELFSUPERTHIS">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="OC.STRING">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="OC.STRUCT_FIELD">
+            <value>
+                <option name="FOREGROUND" value="9373a5" />
+            </value>
+        </option>
+        <option name="OC_FORMAT_TOKEN">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="PARAMETER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="PHP_CLASS">
+            <value>
+                <option name="FOREGROUND" value="ffcb6b" />
+            </value>
+        </option>
+        <option name="PHP_EXEC_COMMAND_ID">
+            <value>
+                <option name="FOREGROUND" value="a5c25c" />
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="PHP_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="2c9ea7" />
+            </value>
+        </option>
+        <option name="PHP_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="PHP_TAG">
+            <value>
+                <option name="FOREGROUND" value="be2c23" />
+            </value>
+        </option>
+        <option name="PHP_VAR">
+            <value>
+                <option name="FOREGROUND" value="ff5370" />
+            </value>
+        </option>
+        <option name="PROPERTIES.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+                <option name="BACKGROUND" value="252b39" />
+                <option name="EFFECT_COLOR" value="ff0000" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PROPERTIES.KEY">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
+            <value>
+                <option name="FOREGROUND" value="c3cee3" />
+            </value>
+        </option>
+        <option name="PROPERTIES.VALUE">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="PROTOCOL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="219598" />
+            </value>
+        </option>
+        <option name="REGEXP.BRACES">
+            <value>
+                <option name="FOREGROUND" value="2c9ea7" />
+            </value>
+        </option>
+        <option name="REGEXP.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="REGEXP.CHAR_CLASS">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+            </value>
+        </option>
+        <option name="REGEXP.ESC_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="REGEXP.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8" />
+                <option name="EFFECT_COLOR" value="bc3f3c" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="REGEXP.META">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="REGEXP.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="798194" />
+            </value>
+        </option>
+        <option name="REGEXP.QUOTE_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="REST.FIXED">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="REST.INLINE">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="REST.INTERPRETED">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="SASS_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="c2c8d7" />
+            </value>
+        </option>
+        <option name="SASS_MIXIN">
+            <value>
+                <option name="FOREGROUND" value="c792ea" />
+            </value>
+        </option>
+        <option name="SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="1e3445" />
+                <option name="BACKGROUND" value="f8e71c" />
+            </value>
+        </option>
+        <option name="SQL_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="SQL_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f25619" />
+            </value>
+        </option>
+        <option name="SQL_STRING">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="SQL_SYNTHETIC_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="STATIC_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="FONT_TYPE" value="2" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f77669" />
+                <option name="FONT_TYPE" value="2" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="Static property reference ID">
+            <value>
+                <option name="FOREGROUND" value="1a1f29" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="String">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="TAPESTRY_COMPONENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="bd92ea" />
+            </value>
+        </option>
+        <option name="TEXT">
+            <value>
+                <option name="FOREGROUND" value="c3cee3" />
+                <option name="BACKGROUND" value="263238" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
+        <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="f8e71c" />
+            </value>
+        </option>
+        <option name="TODO_DEFAULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffeb95" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="TYPEDEF">
+            <value>
+                <option name="FOREGROUND" value="c7c8f5" />
+            </value>
+        </option>
+        <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+            </value>
+        </option>
+        <option name="TYPO">
+            <value>
+                <option name="EFFECT_COLOR" value="ffeb95" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="UNMATCHED_BRACE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="d1243b" />
+            </value>
+        </option>
+        <option name="Unresolved reference access">
+            <value>
+                <option name="FOREGROUND" value="808080" />
+                <option name="EFFECT_COLOR" value="808080" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="VELOCITY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="VELOCITY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="VELOCITY_SCRIPTING_BACKGROUND">
+            <value>
+                <option name="BACKGROUND" value="252b39" />
+            </value>
+        </option>
+        <option name="Valid string escape">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+            </value>
+        </option>
+        <option name="WARNING_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="1e2b31" />
+                <option name="EFFECT_COLOR" value="e6a247" />
+                <option name="ERROR_STRIPE_COLOR" value="e6a247" />
+                <option name="EFFECT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="34434a" />
+                <option name="ERROR_STRIPE_COLOR" value="4d6168" />
+                <option name="EFFECT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="202431" />
+            </value>
+        </option>
+        <option name="WRONG_REFERENCES_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="bc3f3c" />
+            </value>
+        </option>
+        <option name="XML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffc251" />
+            </value>
+        </option>
+        <option name="XML_NS_PREFIX">
+            <value>
+                <option name="FOREGROUND" value="ffc251" />
+            </value>
+        </option>
+        <option name="XML_TAG_DATA">
+            <value>
+                <option name="FOREGROUND" value="c3e887" />
+                <option name="EFFECT_TYPE" value="5" />
+            </value>
+        </option>
+        <option name="XML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="ff355b" />
+            </value>
+        </option>
+        <option name="XPATH.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="XPATH.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f25619" />
+            </value>
+        </option>
+        <option name="XPATH.STRING">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="XPATH.XPATH_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="f38630" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="YAML_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="505c63" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="YAML_SCALAR_DSTRING">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="YAML_SCALAR_KEY">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="YAML_SCALAR_STRING">
+            <value>
+                <option name="FOREGROUND" value="f36e3a" />
+            </value>
+        </option>
+        <option name="YAML_SCALAR_VALUE">
+            <value>
+                <option name="FOREGROUND" value="f25619" />
+            </value>
+        </option>
+        <option name="osmorc.headerName">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+    </attributes>
 </scheme>

--- a/resources/colors/Material Theme - Default.xml
+++ b/resources/colors/Material Theme - Default.xml
@@ -586,6 +586,47 @@
                 <option name="FOREGROUND" value="798891" />
             </value>
         </option>
+        <option name="DJANGO_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="DJANGO_FILTER">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="DJANGO_ID">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="DJANGO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="DJANGO_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="DJANGO_STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_START_END">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
         <option name="DUPLICATE_FROM_SERVER">
             <value />
         </option>
@@ -1204,6 +1245,100 @@
                 <option name="FONT_TYPE" value="1" />
             </value>
         </option>
+        <option name="PY.BRACES">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.CLASS_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="PY.COMMA">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.DOT">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.FUNC_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="PY.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="PY.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="PY.STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="PY.VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
         <option name="REST.FIXED">
             <value>
                 <option name="BACKGROUND" value="252b39" />
@@ -1219,14 +1354,285 @@
                 <option name="BACKGROUND" value="252b39" />
             </value>
         </option>
+        <option name="RHTML_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_END_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_START_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_OMIT_NEW_LINE_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_END_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_START_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="RUBY_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COLON">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COMMA">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="RUBY_CVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_DOT">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_EXPR_IN_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_GVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_HASH_ASSOC">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_INTERPOLATED_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="RUBY_IVAR">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="RUBY_LINE_CONTINUATION">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_LOCAL_VAR_ID">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_METHOD_NAME">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
+        <option name="RUBY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="RUBY_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value>
+                <option name="FOREGROUND" value="82AAFF" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMETER_ID">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="RUBY_REGEXP">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="89DDFF" />
+            </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value>
+                <option name="FOREGROUND" value="eeffff" />
+            </value>
+        </option>
+        <option name="RUBY_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="RUBY_WORDS">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="SASS_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="546E7A" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="SASS_DEFAULT">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_EXTEND">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
         <option name="SASS_IDENTIFIER">
             <value>
-                <option name="FOREGROUND" value="c2c8d7" />
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="SASS_IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="C792EA" />
             </value>
         </option>
         <option name="SASS_MIXIN">
             <value>
-                <option name="FOREGROUND" value="c792ea" />
+                <option name="FOREGROUND" value="C792EA" />
+            </value>
+        </option>
+        <option name="SASS_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="FFCB6B" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_STRING">
+            <value>
+                <option name="FOREGROUND" value="C3E88D" />
+            </value>
+        </option>
+        <option name="SASS_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="f07178" />
+            </value>
+        </option>
+        <option name="SASS_URL">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
+            </value>
+        </option>
+        <option name="SASS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="F78C6C" />
             </value>
         </option>
         <option name="SEARCH_RESULT_ATTRIBUTES">

--- a/resources/colors/Material Theme - Default.xml
+++ b/resources/colors/Material Theme - Default.xml
@@ -1,1465 +1,2557 @@
-<scheme name="Material Theme - Default" version="142" parent_scheme="Default">
-    <option name="LINE_SPACING" value="1.6" />
-    <font>
-        <option name="EDITOR_FONT_NAME" value="Fira Code" />
-        <option name="EDITOR_FONT_SIZE" value="15" />
-    </font>
-    <font>
-        <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
-        <option name="EDITOR_FONT_SIZE" value="12" />
-    </font>
-    <option name="CONSOLE_FONT_NAME" value="Menlo" />
-    <option name="CONSOLE_FONT_SIZE" value="12" />
-    <colors>
-        <option name="ADDED_LINES_COLOR" value="212c32" />
-        <option name="ANNOTATIONS_COLOR" value="8b999f" />
-        <option name="BORDER_LINES_COLOR" value="" />
-        <option name="CARET_COLOR" value="ffcc00" />
-        <option name="CARET_ROW_COLOR" value="222f35" />
-        <option name="CONSOLE_BACKGROUND_KEY" value="263238" />
-        <option name="DELETED_LINES_COLOR" value="f77669" />
-        <option name="DIFF_SEPARATORS_BACKGROUND" value="1e2a30" />
-        <option name="DIFF_SEPARATORS_TOP_BORDER" value="1b262b" />
-        <option name="FILESTATUS_ADDED" value="80cbc4" />
-        <option name="FILESTATUS_COPIED" value="659d9a" />
-        <option name="FILESTATUS_DELETED" value="f77669" />
-        <option name="FILESTATUS_HIJACKED" value="ffcb6b" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="f77669" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="546e7a" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
-        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
-        <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="c3e88d" />
-        <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="546e7a" />
-        <option name="FILESTATUS_MERGED" value="65738e" />
-        <option name="FILESTATUS_MODIFIED" value="80cbc4" />
-        <option name="FILESTATUS_NOT_CHANGED" value="" />
-        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80cbc4" />
-        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80cbc4" />
-        <option name="FILESTATUS_UNKNOWN" value="f77669" />
-        <option name="FILESTATUS_addedOutside" value="629755" />
-        <option name="FILESTATUS_changelistConflict" value="d5756c" />
-        <option name="FILESTATUS_modifiedOutside" value="80cbc4" />
-        <option name="GUTTER_BACKGROUND" value="263238" />
-        <option name="INDENT_GUIDE" value="" />
-        <option name="LINE_NUMBERS_COLOR" value="475f63" />
-        <option name="METHOD_SEPARATORS_COLOR" value="2e3c43" />
-        <option name="MODIFIED_LINES_COLOR" value="99b89d" />
-        <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
-        <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
-        <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
-        <option name="RIGHT_MARGIN_COLOR" value="2e3c43" />
-        <option name="SELECTED_INDENT_GUIDE" value="505050" />
-        <option name="SELECTED_TEARLINE_COLOR" value="99b89d" />
-        <option name="SELECTION_BACKGROUND" value="314549" />
-        <option name="SELECTION_FOREGROUND" value="" />
-        <option name="SOFT_WRAP_SIGN_COLOR" value="4f6269" />
-        <option name="TEARLINE_COLOR" value="3b4950" />
-        <option name="WHITESPACES" value="2e3c43" />
-        <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="99b89d" />
-        <option name="DIFF_SEPARATORS_BACKGROUND" value="1E2A30"/>
-        <option name="DIFF_SEPARATORS_TOP_BORDER" value="1B262B"/>
-    </colors>
-    <attributes>
-        <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="d0d0ff" />
-            </value>
-        </option>
-        <option name="ANNOTATION_NAME_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="fad430" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="BAD_CHARACTER">
-            <value>
-                <option name="EFFECT_COLOR" value="ff5370" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="BASH.CONDITIONAL">
-            <value>
-                <option name="FOREGROUND" value="2c9ea7" />
-            </value>
-        </option>
-        <option name="BASH.EXTERNAL_COMMAND">
-            <value>
-                <option name="FOREGROUND" value="e4cb8f" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="BASH.INTERNAL_COMMAND">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="BASH.VAR_DEF">
-            <value>
-                <option name="FOREGROUND" value="c2c8d7" />
-            </value>
-        </option>
-        <option name="BASH.VAR_USE">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="BLADE_DIRECTIVE">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="BNF_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="1a1f29" />
-            </value>
-        </option>
-        <option name="BNF_NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="BREAKPOINT_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="CLASS_NAME_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffcb6b" />
-            </value>
-        </option>
-        <option name="CLASS_REFERENCE">
-            <value>
-                <option name="FOREGROUND" value="1a1f29" />
-            </value>
-        </option>
-        <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
-            <value>
-                <option name="FOREGROUND" value="dee3ec" />
-                <option name="EFFECT_TYPE" value="5" />
-            </value>
-        </option>
-        <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
-            <value>
-                <option name="FOREGROUND" value="dee3ec" />
-                <option name="EFFECT_TYPE" value="5" />
-            </value>
-        </option>
-        <option name="COFFEESCRIPT.PARAMETER">
-            <value>
-                <option name="EFFECT_COLOR" value="dee3ec" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="CONDITIONALLY_NOT_COMPILED">
-            <value>
-                <option name="FOREGROUND" value="536c46" />
-            </value>
-        </option>
-        <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="7eaef1" />
-            </value>
-        </option>
-        <option name="CONSOLE_BLUE_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="5394ec" />
-            </value>
-        </option>
-        <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="6cdada" />
-            </value>
-        </option>
-        <option name="CONSOLE_CYAN_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="33cccc" />
-            </value>
-        </option>
-        <option name="CONSOLE_ERROR_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff6b68" />
-            </value>
-        </option>
-        <option name="CONSOLE_GRAY_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="999999" />
-            </value>
-        </option>
-        <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="70ff70" />
-            </value>
-        </option>
-        <option name="CONSOLE_GREEN_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="7f00" />
-            </value>
-        </option>
-        <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff99ff" />
-            </value>
-        </option>
-        <option name="CONSOLE_MAGENTA_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff70ff" />
-            </value>
-        </option>
-        <option name="CONSOLE_NORMAL_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-            </value>
-        </option>
-        <option name="CONSOLE_OUTPUT">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="CONSOLE_RANGE_TO_EXECUTE">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="CONSOLE_RED_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff8785" />
-            </value>
-        </option>
-        <option name="CONSOLE_RED_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff6b68" />
-            </value>
-        </option>
-        <option name="CONSOLE_SYSTEM_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="f8f8f0" />
-            </value>
-        </option>
-        <option name="CONSOLE_WHITE_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="f8f8f0" />
-            </value>
-        </option>
-        <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ffff00" />
-            </value>
-        </option>
-        <option name="CONSOLE_YELLOW_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="cdcd00" />
-            </value>
-        </option>
-        <option name="CSS.BRACKETS">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="CSS.COLOR">
-            <value>
-                <option name="FOREGROUND" value="ffea7d" />
-            </value>
-        </option>
-        <option name="CSS.DOT">
-            <value>
-                <option name="FOREGROUND" value="ffc251" />
-            </value>
-        </option>
-        <option name="CSS.FUNCTION">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="CSS.HASH">
-            <value>
-                <option name="FOREGROUND" value="f9cf0a" />
-            </value>
-        </option>
-        <option name="CSS.IDENT">
-            <value>
-                <option name="FOREGROUND" value="ffc251" />
-            </value>
-        </option>
-        <option name="CSS.IMPORTANT">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="CSS.NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f55e53" />
-            </value>
-        </option>
-        <option name="CSS.OPERATORS">
-            <value>
-                <option name="FOREGROUND" value="f55e53" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="CSS.PARENTHESES">
-            <value>
-                <option name="FOREGROUND" value="c2c8d7" />
-            </value>
-        </option>
-        <option name="CSS.PROPERTY_NAME">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="CSS.PROPERTY_VALUE">
-            <value>
-                <option name="FOREGROUND" value="c3cee3" />
-            </value>
-        </option>
-        <option name="CSS.PSEUDO">
-            <value>
-                <option name="FOREGROUND" value="ffc251" />
-            </value>
-        </option>
-        <option name="CSS.TAG_NAME">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="CSS.UNICODE.RANGE">
-            <value>
-                <option name="FOREGROUND" value="f55e53" />
-            </value>
-        </option>
-        <option name="CSS.URL">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="CTRL_CLICKABLE">
-            <value>
-                <option name="FOREGROUND" value="58bcb3" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="8000" />
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="82b1ff" />
-            </value>
-        </option>
-        <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ab51ba" />
-            </value>
-        </option>
-        <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="f9795" />
-            </value>
-        </option>
-        <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="CUSTOM_NUMBER_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="CUSTOM_STRING_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="6a8759" />
-            </value>
-        </option>
-        <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="4646f1" />
-            </value>
-        </option>
-        <option name="DEFAULT_ATTRIBUTE">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="DEFAULT_BLOCK_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="546e7a" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="DEFAULT_BRACES">
-            <value>
-                <option name="FOREGROUND" value="cad3de" />
-            </value>
-        </option>
-        <option name="DEFAULT_BRACKETS">
-            <value>
-                <option name="FOREGROUND" value="cad3de" />
-            </value>
-        </option>
-        <option name="DEFAULT_CLASS_NAME">
-            <value>
-                <option name="FOREGROUND" value="ffcb6b" />
-            </value>
-        </option>
-        <option name="DEFAULT_CONSTANT">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="DEFAULT_DOC_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="546e7a" />
-            </value>
-        </option>
-        <option name="DEFAULT_DOC_COMMENT_TAG">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
-            <value>
-                <option name="FOREGROUND" value="546e7a" />
-                <option name="FONT_TYPE" value="3" />
-            </value>
-        </option>
-        <option name="DEFAULT_DOC_MARKUP">
-            <value>
-                <option name="FOREGROUND" value="546e7a" />
-            </value>
-        </option>
-        <option name="DEFAULT_ENTITY">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="DEFAULT_FUNCTION_CALL">
-            <value>
-                <option name="FOREGROUND" value="82b1ff" />
-            </value>
-        </option>
-        <option name="DEFAULT_FUNCTION_DECLARATION">
-            <value>
-                <option name="FOREGROUND" value="82b1ff" />
-            </value>
-        </option>
-        <option name="DEFAULT_IDENTIFIER">
-            <value>
-                <option name="FOREGROUND" value="c3d3de" />
-            </value>
-        </option>
-        <option name="DEFAULT_INSTANCE_FIELD">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="DEFAULT_INVALID_STRING_ESCAPE">
-            <value>
-                <option name="EFFECT_COLOR" value="ff5370" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="DEFAULT_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="DEFAULT_LINE_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="546e7a" />
-            </value>
-        </option>
-        <option name="DEFAULT_LOCAL_VARIABLE">
-            <value>
-                <option name="FOREGROUND" value="92bdec" />
-            </value>
-        </option>
-        <option name="DEFAULT_METADATA">
-            <value>
-                <option name="FOREGROUND" value="bbb529" />
-            </value>
-        </option>
-        <option name="DEFAULT_NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-            </value>
-        </option>
-        <option name="DEFAULT_OPERATION_SIGN">
-            <value>
-                <option name="FOREGROUND" value="80cbc4" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="DEFAULT_PARAMETER">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="DEFAULT_PARENTHS">
-            <value>
-                <option name="FOREGROUND" value="798194" />
-            </value>
-        </option>
-        <option name="DEFAULT_PREDEFINED_SYMBOL">
-            <value>
-                <option name="FOREGROUND" value="58bcb3" />
-            </value>
-        </option>
-        <option name="DEFAULT_STATIC_FIELD">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="DEFAULT_STATIC_METHOD">
-            <value>
-                <option name="FOREGROUND" value="8dc4f0" />
-            </value>
-        </option>
-        <option name="DEFAULT_STRING">
-            <value>
-                <option name="FOREGROUND" value="c3e887" />
-            </value>
-        </option>
-        <option name="DEFAULT_TAG">
-            <value />
-        </option>
-        <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="BACKGROUND" value="263238" />
-                <option name="EFFECT_TYPE" value="5" />
-            </value>
-        </option>
-        <option name="DEFAULT_VALID_STRING_ESCAPE">
-            <value />
-        </option>
-        <option name="DELETED_TEXT_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-                <option name="EFFECT_COLOR" value="c14360" />
-                <option name="EFFECT_TYPE" value="3" />
-            </value>
-        </option>
-        <option name="DEPRECATED_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-                <option name="BACKGROUND" value="d3423e" />
-                <option name="EFFECT_TYPE" value="3" />
-            </value>
-        </option>
-        <option name="DIFF_CONFLICT">
-            <value>
-                <option name="BACKGROUND" value="b03435" />
-                <option name="ERROR_STRIPE_COLOR" value="b03435" />
-            </value>
-        </option>
-        <option name="DIFF_DELETED">
-            <value>
-                <option name="BACKGROUND" value="656e76" />
-                <option name="ERROR_STRIPE_COLOR" value="656e76" />
-            </value>
-        </option>
-        <option name="DIFF_INSERTED">
-            <value>
-                <option name="BACKGROUND" value="447152" />
-                <option name="ERROR_STRIPE_COLOR" value="447152" />
-            </value>
-        </option>
-        <option name="DIFF_MODIFIED">
-            <value>
-                <option name="BACKGROUND" value="43698d" />
-                <option name="ERROR_STRIPE_COLOR" value="43698d" />
-            </value>
-        </option>
-        <option name="DOC_COMMENT_TAG_VALUE">
-            <value>
-                <option name="FOREGROUND" value="798891" />
-            </value>
-        </option>
-        <option name="DUPLICATE_FROM_SERVER">
-            <value />
-        </option>
-        <option name="ENUM_CONST">
-            <value>
-                <option name="FOREGROUND" value="9373a5" />
-            </value>
-        </option>
-        <option name="ERRORS_ATTRIBUTES">
-            <value>
-                <option name="EFFECT_COLOR" value="ff5370" />
-                <option name="ERROR_STRIPE_COLOR" value="b23e56" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="EXECUTIONPOINT_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="FOLDED_TEXT_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="f3f349" />
-            </value>
-        </option>
-        <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="80cbc4" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="GENERIC_SERVER_ERROR_OR_WARNING">
-            <value>
-                <option name="EFFECT_COLOR" value="f49810" />
-                <option name="ERROR_STRIPE_COLOR" value="f49810" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="GROOVY_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="GString">
-            <value>
-                <option name="FOREGROUND" value="6a8759" />
-            </value>
-        </option>
-        <option name="Groovydoc comment">
-            <value>
-                <option name="FOREGROUND" value="629755" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="Groovydoc tag">
-            <value>
-                <option name="FOREGROUND" value="7cb36f" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="HAML_RUBY_CODE">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="HAML_TAG">
-            <value>
-                <option name="FOREGROUND" value="c3cee3" />
-            </value>
-        </option>
-        <option name="HTML_ATTRIBUTE_NAME">
-            <value>
-                <option name="FOREGROUND" value="ffcb6b" />
-            </value>
-        </option>
-        <option name="HTML_ATTRIBUTE_VALUE">
-            <value>
-                <option name="FOREGROUND" value="c3e887" />
-            </value>
-        </option>
-        <option name="HTML_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="505c63" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="HTML_ENTITY_REFERENCE">
-            <value>
-                <option name="FOREGROUND" value="92bdec" />
-            </value>
-        </option>
-        <option name="HTML_TAG">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="HTML_TAG_NAME">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="HYPERLINK_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="58bcb3" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="34434a" />
-                <option name="ERROR_STRIPE_COLOR" value="4d6168" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="IGNORE.VALUE">
-            <value>
-                <option name="FOREGROUND" value="c77554" />
-            </value>
-        </option>
-        <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="b389c5" />
-                <option name="EFFECT_COLOR" value="b389c5" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="INFO_ATTRIBUTES">
-            <value>
-                <option name="EFFECT_COLOR" value="d9b2d5" />
-                <option name="ERROR_STRIPE_COLOR" value="aeae80" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="INJECTED_LANGUAGE_FRAGMENT">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-            </value>
-        </option>
-        <option name="INSTANCE_FIELD_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="INTERFACE_NAME_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="c3e88d" />
-            </value>
-        </option>
-        <option name="IVAR">
-            <value>
-                <option name="FOREGROUND" value="9373a5" />
-            </value>
-        </option>
-        <option name="Instance field">
-            <value />
-        </option>
-        <option name="Instance property reference ID" baseAttributes="INSTANCE_FIELD_ATTRIBUTES" />
-        <option name="JAVA_COMMA">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="JAVA_DOC_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="505c63" />
-            </value>
-        </option>
-        <option name="JAVA_DOC_TAG">
-            <value>
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="JAVA_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="JAVA_NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-            </value>
-        </option>
-        <option name="JAVA_SEMICOLON">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="JAVA_VALID_STRING_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="JFLEX_MACROS_REF">
-            <value>
-                <option name="FOREGROUND" value="1a1f29" />
-            </value>
-        </option>
-        <option name="JS.GLOBAL_FUNCTION">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-            </value>
-        </option>
-        <option name="JS.GLOBAL_VARIABLE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.INSTANCE_MEMBER_FUNCTION">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.INSTANCE_MEMBER_VARIABLE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.INVALID_STRING_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="c3e887" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="JS.LOCAL_VARIABLE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.PARAMETER">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-            </value>
-        </option>
-        <option name="JS.PARENTHS">
-            <value>
-                <option name="FOREGROUND" value="d0f5d4" />
-            </value>
-        </option>
-        <option name="JS.REGEXP">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.SEMICOLON">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JS.VALID_STRING_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JSON.INVALID_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-                <option name="BACKGROUND" value="e74552" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="JSON.KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="f55e53" />
-            </value>
-        </option>
-        <option name="JSON.NUMBER">
-            <value>
-                <option name="FOREGROUND" value="b7e876" />
-            </value>
-        </option>
-        <option name="JSON.PROPERTY_KEY">
-            <value>
-                <option name="FOREGROUND" value="b7e876" />
-            </value>
-        </option>
-        <option name="JSON.STRING">
-            <value>
-                <option name="FOREGROUND" value="b7e876" />
-            </value>
-        </option>
-        <option name="JSON.VALID_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="JSP_DIRECTIVE_NAME">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="JSP_SCRIPTING_BACKGROUND">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="KOTLIN_ANNOTATION">
-            <value />
-        </option>
-        <option name="KOTLIN_IMPLICIT_EXHAUSTIVE_WHEN">
-            <value />
-        </option>
-        <option name="KOTLIN_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
-            <value />
-        </option>
-        <option name="KOTLIN_SMART_CAST_RECEIVER">
-            <value />
-        </option>
-        <option name="KOTLIN_SMART_CAST_VALUE">
-            <value />
-        </option>
-        <option name="KOTLIN_SMART_CONSTANT">
-            <value />
-        </option>
-        <option name="LABEL">
-            <value>
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="LINE_FULL_COVERAGE">
-            <value>
-                <option name="BACKGROUND" value="1fc700" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="LINE_NONE_COVERAGE">
-            <value>
-                <option name="BACKGROUND" value="ab1c07" />
-                <option name="FONT_TYPE" value="1" />
-                <option name="EFFECT_TYPE" value="3" />
-            </value>
-        </option>
-        <option name="LINE_PARTIAL_COVERAGE">
-            <value>
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="LOG_ERROR_OUTPUT">
-            <value>
-                <option name="FOREGROUND" value="ff6b68" />
-            </value>
-        </option>
-        <option name="List/map to object conversion">
-            <value>
-                <option name="FOREGROUND" value="e8bf6a" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="MACRONAME">
-            <value>
-                <option name="FOREGROUND" value="908b25" />
-            </value>
-        </option>
-        <option name="MAGIC_MEMBER_ACCESS">
-            <value>
-                <option name="FOREGROUND" value="20c5c3" />
-            </value>
-        </option>
-        <option name="MARKDOWN.AUTO_LINK">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.BULLET_LIST">
-            <value>
-                <option name="FOREGROUND" value="646877" />
-            </value>
-        </option>
-        <option name="MARKDOWN.EXPLICIT_LINK">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="MARKDOWN.HEADER_LEVEL_1">
-            <value>
-                <option name="FOREGROUND" value="63c0ee" />
-            </value>
-        </option>
-        <option name="MARKDOWN.HEADER_LEVEL_2">
-            <value>
-                <option name="FOREGROUND" value="63c0ee" />
-            </value>
-        </option>
-        <option name="MARKDOWN.HEADER_LEVEL_3">
-            <value>
-                <option name="FOREGROUND" value="63c0ee" />
-            </value>
-        </option>
-        <option name="MARKDOWN.HEADER_LEVEL_4">
-            <value>
-                <option name="FOREGROUND" value="63c0ee" />
-            </value>
-        </option>
-        <option name="MARKDOWN.HEADER_LEVEL_5">
-            <value>
-                <option name="FOREGROUND" value="63c0ee" />
-            </value>
-        </option>
-        <option name="MARKDOWN.IMAGE">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.MAIL_LINK">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.REFERENCE">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.REFERENCE_IMAGE">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.REFERENCE_LINK">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="MARKDOWN.TEXT">
-            <value>
-                <option name="FOREGROUND" value="c3cee3" />
-            </value>
-        </option>
-        <option name="MATCHED_BRACE_ATTRIBUTES">
-            <value>
-                <option name="FONT_TYPE" value="1" />
-                <option name="EFFECT_COLOR" value="b39613" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="MESSAGE_ARGUMENT">
-            <value>
-                <option name="FOREGROUND" value="c4b3a3" />
-            </value>
-        </option>
-        <option name="METHOD_DECLARATION_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="82b1ff" />
-            </value>
-        </option>
-        <option name="NOT_USED_ELEMENT_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="808080" />
-                <option name="EFFECT_COLOR" value="808080" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="Number">
-            <value>
-                <option name="FOREGROUND" value="f25619" />
-            </value>
-        </option>
-        <option name="OC.CPP_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="OC.DIRECTIVE">
-            <value>
-                <option name="FOREGROUND" value="80b000" />
-            </value>
-        </option>
-        <option name="OC.KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="OC.NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f25619" />
-            </value>
-        </option>
-        <option name="OC.PROPERTY">
-            <value>
-                <option name="FOREGROUND" value="cdbcac" />
-            </value>
-        </option>
-        <option name="OC.SELFSUPERTHIS">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="OC.STRING">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="OC.STRUCT_FIELD">
-            <value>
-                <option name="FOREGROUND" value="9373a5" />
-            </value>
-        </option>
-        <option name="OC_FORMAT_TOKEN">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="PARAMETER_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="PHP_CLASS">
-            <value>
-                <option name="FOREGROUND" value="ffcb6b" />
-            </value>
-        </option>
-        <option name="PHP_EXEC_COMMAND_ID">
-            <value>
-                <option name="FOREGROUND" value="a5c25c" />
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="PHP_HEREDOC_ID">
-            <value>
-                <option name="FOREGROUND" value="2c9ea7" />
-            </value>
-        </option>
-        <option name="PHP_PARAMETER">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="PHP_TAG">
-            <value>
-                <option name="FOREGROUND" value="be2c23" />
-            </value>
-        </option>
-        <option name="PHP_VAR">
-            <value>
-                <option name="FOREGROUND" value="ff5370" />
-            </value>
-        </option>
-        <option name="PROPERTIES.INVALID_STRING_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-                <option name="BACKGROUND" value="252b39" />
-                <option name="EFFECT_COLOR" value="ff0000" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="PROPERTIES.KEY">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
-            <value>
-                <option name="FOREGROUND" value="c3cee3" />
-            </value>
-        </option>
-        <option name="PROPERTIES.VALUE">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="PROTOCOL_REFERENCE">
-            <value>
-                <option name="FOREGROUND" value="219598" />
-            </value>
-        </option>
-        <option name="REGEXP.BRACES">
-            <value>
-                <option name="FOREGROUND" value="2c9ea7" />
-            </value>
-        </option>
-        <option name="REGEXP.BRACKETS">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="REGEXP.CHAR_CLASS">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-            </value>
-        </option>
-        <option name="REGEXP.ESC_CHARACTER">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="REGEXP.INVALID_STRING_ESCAPE">
-            <value>
-                <option name="FOREGROUND" value="6dc2b8" />
-                <option name="EFFECT_COLOR" value="bc3f3c" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="REGEXP.META">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="REGEXP.PARENTHS">
-            <value>
-                <option name="FOREGROUND" value="798194" />
-            </value>
-        </option>
-        <option name="REGEXP.QUOTE_CHARACTER">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="REST.FIXED">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="REST.INLINE">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="REST.INTERPRETED">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="SASS_IDENTIFIER">
-            <value>
-                <option name="FOREGROUND" value="c2c8d7" />
-            </value>
-        </option>
-        <option name="SASS_MIXIN">
-            <value>
-                <option name="FOREGROUND" value="c792ea" />
-            </value>
-        </option>
-        <option name="SEARCH_RESULT_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="1e3445" />
-                <option name="BACKGROUND" value="f8e71c" />
-            </value>
-        </option>
-        <option name="SQL_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="SQL_NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f25619" />
-            </value>
-        </option>
-        <option name="SQL_STRING">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="SQL_SYNTHETIC_ENTITY">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="STATIC_FIELD_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-                <option name="FONT_TYPE" value="2" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="f77669" />
-                <option name="FONT_TYPE" value="2" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="Static property reference ID">
-            <value>
-                <option name="FOREGROUND" value="1a1f29" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="String">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="TAPESTRY_COMPONENT_TAG">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="bd92ea" />
-            </value>
-        </option>
-        <option name="TEXT">
-            <value>
-                <option name="FOREGROUND" value="c3cee3" />
-                <option name="BACKGROUND" value="263238" />
-                <option name="EFFECT_TYPE" value="5" />
-            </value>
-        </option>
-        <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
-            <value>
-                <option name="EFFECT_COLOR" value="f8e71c" />
-            </value>
-        </option>
-        <option name="TODO_DEFAULT_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffeb95" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="TYPEDEF">
-            <value>
-                <option name="FOREGROUND" value="c7c8f5" />
-            </value>
-        </option>
-        <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="ffffff" />
-            </value>
-        </option>
-        <option name="TYPO">
-            <value>
-                <option name="EFFECT_COLOR" value="ffeb95" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="UNMATCHED_BRACE_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="d1243b" />
-            </value>
-        </option>
-        <option name="Unresolved reference access">
-            <value>
-                <option name="FOREGROUND" value="808080" />
-                <option name="EFFECT_COLOR" value="808080" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="VELOCITY_KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="VELOCITY_NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="VELOCITY_SCRIPTING_BACKGROUND">
-            <value>
-                <option name="BACKGROUND" value="252b39" />
-            </value>
-        </option>
-        <option name="Valid string escape">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-            </value>
-        </option>
-        <option name="WARNING_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="1e2b31" />
-                <option name="EFFECT_COLOR" value="e6a247" />
-                <option name="ERROR_STRIPE_COLOR" value="e6a247" />
-                <option name="EFFECT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="34434a" />
-                <option name="ERROR_STRIPE_COLOR" value="4d6168" />
-                <option name="EFFECT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
-            <value>
-                <option name="BACKGROUND" value="202431" />
-            </value>
-        </option>
-        <option name="WRONG_REFERENCES_ATTRIBUTES">
-            <value>
-                <option name="FOREGROUND" value="bc3f3c" />
-            </value>
-        </option>
-        <option name="XML_ATTRIBUTE_NAME">
-            <value>
-                <option name="FOREGROUND" value="ffc251" />
-            </value>
-        </option>
-        <option name="XML_NS_PREFIX">
-            <value>
-                <option name="FOREGROUND" value="ffc251" />
-            </value>
-        </option>
-        <option name="XML_TAG_DATA">
-            <value>
-                <option name="FOREGROUND" value="c3e887" />
-                <option name="EFFECT_TYPE" value="5" />
-            </value>
-        </option>
-        <option name="XML_TAG_NAME">
-            <value>
-                <option name="FOREGROUND" value="ff355b" />
-            </value>
-        </option>
-        <option name="XPATH.KEYWORD">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="XPATH.NUMBER">
-            <value>
-                <option name="FOREGROUND" value="f25619" />
-            </value>
-        </option>
-        <option name="XPATH.STRING">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="XPATH.XPATH_VARIABLE">
-            <value>
-                <option name="FOREGROUND" value="f38630" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-        <option name="YAML_COMMENT">
-            <value>
-                <option name="FOREGROUND" value="505c63" />
-                <option name="FONT_TYPE" value="2" />
-            </value>
-        </option>
-        <option name="YAML_SCALAR_DSTRING">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="YAML_SCALAR_KEY">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="YAML_SCALAR_STRING">
-            <value>
-                <option name="FOREGROUND" value="f36e3a" />
-            </value>
-        </option>
-        <option name="YAML_SCALAR_VALUE">
-            <value>
-                <option name="FOREGROUND" value="f25619" />
-            </value>
-        </option>
-        <option name="osmorc.headerName">
-            <value>
-                <option name="FOREGROUND" value="a7dbd8" />
-                <option name="FONT_TYPE" value="1" />
-            </value>
-        </option>
-    </attributes>
+<scheme name="Material Theme (Modified)" parent_scheme="Default" version="1">
+  <option name="LINE_SPACING" value="1.0" />
+  <font>
+    <option name="EDITOR_FONT_SIZE" value="12" />
+    <option name="EDITOR_FONT_NAME" value="Menlo" />
+  </font>
+  <font>
+    <option name="EDITOR_FONT_NAME" value="Fira Code" />
+    <option name="EDITOR_FONT_SIZE" value="15" />
+  </font>
+  <font>
+    <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
+    <option name="EDITOR_FONT_SIZE" value="12" />
+  </font>
+  <option name="CONSOLE_FONT_NAME" value="Menlo" />
+  <option name="CONSOLE_FONT_SIZE" value="12" />
+  <colors>
+    <option name="ADDED_LINES_COLOR" value="212c32" />
+    <option name="ANNOTATIONS_COLOR" value="8b999f" />
+    <option name="BORDER_LINES_COLOR" value="" />
+    <option name="CARET_COLOR" value="FFCC00" />
+    <option name="CARET_ROW_COLOR" value="1a2226" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="263238" />
+    <option name="DELETED_LINES_COLOR" value="f77669" />
+    <option name="DIFF_SEPARATORS_BACKGROUND" value="1e2a30" />
+    <option name="DIFF_SEPARATORS_TOP_BORDER" value="1b262b" />
+    <option name="FILESTATUS_ADDED" value="80cbc4" />
+    <option name="FILESTATUS_COPIED" value="659d9a" />
+    <option name="FILESTATUS_DELETED" value="f77669" />
+    <option name="FILESTATUS_HIJACKED" value="ffcb6b" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="f77669" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="546e7a" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c" />
+    <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="c3e88d" />
+    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="546e7a" />
+    <option name="FILESTATUS_MERGED" value="65738e" />
+    <option name="FILESTATUS_MODIFIED" value="80cbc4" />
+    <option name="FILESTATUS_NOT_CHANGED" value="" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80cbc4" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80cbc4" />
+    <option name="FILESTATUS_UNKNOWN" value="f77669" />
+    <option name="FILESTATUS_addedOutside" value="629755" />
+    <option name="FILESTATUS_changelistConflict" value="d5756c" />
+    <option name="FILESTATUS_modifiedOutside" value="80cbc4" />
+    <option name="GUTTER_BACKGROUND" value="263238" />
+    <option name="INDENT_GUIDE" value="65737e" />
+    <option name="LINE_NUMBERS_COLOR" value="eeffff" />
+    <option name="METHOD_SEPARATORS_COLOR" value="2e3c43" />
+    <option name="MODIFIED_LINES_COLOR" value="99b89d" />
+    <option name="NOTIFICATION_BACKGROUND" value="3d1a11" />
+    <option name="READONLY_FRAGMENT_BACKGROUND" value="" />
+    <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300" />
+    <option name="RIGHT_MARGIN_COLOR" value="2e3c43" />
+    <option name="SELECTED_INDENT_GUIDE" value="65737e" />
+    <option name="SELECTED_TEARLINE_COLOR" value="99b89d" />
+    <option name="SELECTION_BACKGROUND" value="314549" />
+    <option name="SELECTION_FOREGROUND" value="" />
+    <option name="SOFT_WRAP_SIGN_COLOR" value="4f6269" />
+    <option name="TEARLINE_COLOR" value="3b4950" />
+    <option name="WHITESPACES" value="65737e" />
+    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="99b89d" />
+    <option name="DIFF_SEPARATORS_BACKGROUND" value="1E2A30"/>
+    <option name="DIFF_SEPARATORS_TOP_BORDER" value="1B262B"/>
+  </colors>
+  <attributes>
+    <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d0d0ff" />
+      </value>
+    </option>
+    <option name="ANNOTATION_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fad430" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="BAD_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="BASH.CONDITIONAL">
+      <value>
+        <option name="FOREGROUND" value="2c9ea7" />
+      </value>
+    </option>
+    <option name="BASH.EXTERNAL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="e4cb8f" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="BASH.INTERNAL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="6dc2b8" />
+      </value>
+    </option>
+    <option name="BASH.VAR_DEF">
+      <value>
+        <option name="FOREGROUND" value="c2c8d7" />
+      </value>
+    </option>
+    <option name="BASH.VAR_USE">
+      <value>
+        <option name="FOREGROUND" value="ff5370" />
+      </value>
+    </option>
+    <option name="BLADE_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="ff5370" />
+      </value>
+    </option>
+    <option name="BNF_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="1a1f29" />
+      </value>
+    </option>
+    <option name="BNF_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+      </value>
+    </option>
+    <option name="BREAKPOINT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="743d3d" />
+      </value>
+    </option>
+    <option name="BUILDOUT.KEY">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="BUILDOUT.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="BUILDOUT.SECTION_NAME">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="BUILDOUT.VALUE">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ffcb6b" />
+      </value>
+    </option>
+    <option name="CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BAD_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BOOLEAN">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BRACE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.COLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.EXISTENTIAL">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION_BINDING">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION_NAME">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREGEX_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREGEX_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="COFFEESCRIPT.IDENTIFIER" />
+    <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="dee3ec" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.JAVASCRIPT_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option baseAttributes="COFFEESCRIPT.IDENTIFIER" name="COFFEESCRIPT.LOCAL_VARIABLE" />
+    <option name="COFFEESCRIPT.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.OBJECT_KEY">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.OPERATIONS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.PARENTHESIS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.PROTOTYPE">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.RANGE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_FLAG">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.SPLAT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.THIS">
+      <value>
+        <option name="FOREGROUND" value="FF5370" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CONDITIONALLY_NOT_COMPILED">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CONSOLE_BLUE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="c7c7ff" />
+      </value>
+    </option>
+    <option name="CONSOLE_CYAN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="06b8b8" />
+      </value>
+    </option>
+    <option name="CONSOLE_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ffb3b3" />
+      </value>
+    </option>
+    <option name="CONSOLE_GRAY_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="a7a7a7" />
+      </value>
+    </option>
+    <option name="CONSOLE_GREEN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="68e868" />
+      </value>
+    </option>
+    <option name="CONSOLE_MAGENTA_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ff2eff" />
+      </value>
+    </option>
+    <option name="CONSOLE_NORMAL_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+      </value>
+    </option>
+    <option name="CONSOLE_RED_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ff6767" />
+      </value>
+    </option>
+    <option name="CONSOLE_SYSTEM_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="e4e4ff" />
+      </value>
+    </option>
+    <option name="CONSOLE_USER_INPUT">
+      <value>
+        <option name="FOREGROUND" value="6ae96a" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CONSOLE_YELLOW_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="754200" />
+      </value>
+    </option>
+    <option name="CSS.COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CSS.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="CSS.IDENT">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="CSS.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="CSS.PROPERTY_NAME">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="CSS.PROPERTY_VALUE">
+      <value>
+        <option name="FOREGROUND" value="68e868" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CSS.TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="CSS.URL">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="CTRL_CLICKABLE">
+      <value>
+        <option name="FOREGROUND" value="58bcb3" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="e3e3ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="71d7d7" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ffc2c2" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CUSTOM_NUMBER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="CUSTOM_STRING_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="Clojure Atom">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="Clojure Character">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="Clojure Keyword">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="Clojure Line comment">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Clojure Literal">
+      <value>
+        <option name="FOREGROUND" value="FF5370" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Clojure Numbers">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="Clojure Strings">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="DEFAULT_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_BRACES">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="DEFAULT_COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="f77669" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="FF5370" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="DEFAULT_IDENTIFIER" />
+    <option name="DEFAULT_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="52D1DC" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_INSTANCE_METHOD">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_INTERFACE_NAME">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="DEFAULT_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="DEFAULT_LABEL" />
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_METADATA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="DEFAULT_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="F4E04D" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_PREDEFINED_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="DEFAULT_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="52D1DC" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_STATIC_METHOD">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="BACKGROUND" value="263238" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="DEFAULT_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DEPRECATED_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_TYPE" value="3" />
+        <option name="EFFECT_COLOR" value="c0c0c0" />
+      </value>
+    </option>
+    <option name="DIFF_CONFLICT">
+      <value>
+        <option name="BACKGROUND" value="763f34" />
+        <option name="ERROR_STRIPE_COLOR" value="ff6647" />
+      </value>
+    </option>
+    <option name="DIFF_DELETED">
+      <value>
+        <option name="BACKGROUND" value="5b5b5b" />
+        <option name="ERROR_STRIPE_COLOR" value="747474" />
+      </value>
+    </option>
+    <option name="DIFF_INSERTED">
+      <value>
+        <option name="BACKGROUND" value="2f632f" />
+        <option name="ERROR_STRIPE_COLOR" value="99ff99" />
+      </value>
+    </option>
+    <option name="DIFF_MODIFIED">
+      <value>
+        <option name="BACKGROUND" value="465983" />
+        <option name="ERROR_STRIPE_COLOR" value="99ccff" />
+      </value>
+    </option>
+    <option name="DJANGO_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DJANGO_FILTER">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="DJANGO_ID">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="DJANGO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="DJANGO_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="DJANGO_STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="DJANGO_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DJANGO_TAG_START_END">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="DUPLICATE_FROM_SERVER">
+      <value>
+        <option name="BACKGROUND" value="30322b" />
+      </value>
+    </option>
+    <option name="ENUM_CONST">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="ERRORS_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="ff6767" />
+        <option name="ERROR_STRIPE_COLOR" value="ff0000" />
+      </value>
+    </option>
+    <option name="EXECUTIONPOINT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="000101" />
+        <option name="BACKGROUND" value="c7c7ff" />
+      </value>
+    </option>
+    <option name="FOLDED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="3c3d3c" />
+        <option name="BACKGROUND" value="101010" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="3c3d3c" />
+      </value>
+    </option>
+    <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="BACKGROUND" value="161717" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="c7c7ff" />
+      </value>
+    </option>
+    <option name="First symbol in list">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="aa4e00" />
+        <option name="ERROR_STRIPE_COLOR" value="f49810" />
+      </value>
+    </option>
+    <option name="GHERKIN_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="GHERKIN_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="GHERKIN_OUTLINE_PARAMETER_SUBSTITUTION">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="GHERKIN_PYSTRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="GHERKIN_REGEXP_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option baseAttributes="GHERKIN_TEXT" name="GHERKIN_TABLE_CELL" />
+    <option name="GHERKIN_TABLE_HEADER_CELL">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="GHERKIN_TABLE_PIPE">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="GHERKIN_TAG">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="GHERKIN_TEXT" />
+    <option name="GQL_ID">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="GQL_INT_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="GQL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="GQL_STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="GROOVY_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+      </value>
+    </option>
+    <option name="GString">
+      <value>
+        <option name="FOREGROUND" value="6a8759" />
+      </value>
+    </option>
+    <option name="Groovydoc comment">
+      <value>
+        <option name="FOREGROUND" value="629755" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Groovydoc tag">
+      <value>
+        <option name="FOREGROUND" value="7cb36f" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="HAML_CLASS">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="HAML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option baseAttributes="HAML_TEXT" name="HAML_FILTER" />
+    <option baseAttributes="HAML_TEXT" name="HAML_FILTER_CONTENT" />
+    <option name="HAML_ID">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option baseAttributes="HAML_TEXT" name="HAML_LINE_CONTINUATION" />
+    <option name="HAML_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_CODE" />
+    <option baseAttributes="HAML_TEXT" name="HAML_RUBY_START" />
+    <option name="HAML_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="HAML_STRING_INTERPOLATED">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="HAML_TAG">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="HAML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="HAML_TEXT" />
+    <option name="HAML_WS_REMOVAL">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="HAML_TEXT" name="HAML_XHTML" />
+    <option name="HTML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="HTML_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="HTML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="HTML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="HTML_TAG">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="HTML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="c7c7ff" />
+      </value>
+    </option>
+    <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="3c3c57" />
+        <option name="ERROR_STRIPE_COLOR" value="ccccff" />
+      </value>
+    </option>
+    <option name="IGNORE.VALUE">
+      <value>
+        <option name="FOREGROUND" value="c77554" />
+      </value>
+    </option>
+    <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fda5ff" />
+      </value>
+    </option>
+    <option name="INFO_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="333434" />
+        <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
+      </value>
+    </option>
+    <option name="INJECTED_LANGUAGE_FRAGMENT">
+      <value>
+        <option name="BACKGROUND" value="273627" />
+      </value>
+    </option>
+    <option name="INSTANCE_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="INTERFACE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="c3e88d" />
+      </value>
+    </option>
+    <option name="IVAR">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="JADE_FILE_PATH">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option baseAttributes="DEFAULT_LABEL" name="JADE_FILTER_NAME" />
+    <option baseAttributes="DEFAULT_IDENTIFIER" name="JADE_JS_BLOCK" />
+    <option name="JADE_STATEMENTS">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="JAVA_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JAVA_BRACES">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_MARKUP">
+      <value>
+        <option name="BACKGROUND" value="223f22" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_TAG">
+      <value>
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="80807f" />
+      </value>
+    </option>
+    <option name="JAVA_DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="JAVA_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="JAVA_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JAVA_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="JAVA_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_PARENTH">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JAVA_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="JAVA_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JFLEX_MACROS_REF">
+      <value>
+        <option name="FOREGROUND" value="1a1f29" />
+      </value>
+    </option>
+    <option name="JS.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="FF5370" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.INSTANCE_MEMBER_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="JS.INSTANCE_MEMBER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="52D1DC" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="EEFFFF" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="F4E04D" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.REGEXP">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="JSON.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="f55e53" />
+      </value>
+    </option>
+    <option name="JSON.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b7e876" />
+      </value>
+    </option>
+    <option name="JSON.PROPERTY_KEY">
+      <value>
+        <option name="FOREGROUND" value="b7e876" />
+      </value>
+    </option>
+    <option name="JSON.STRING">
+      <value>
+        <option name="FOREGROUND" value="b7e876" />
+      </value>
+    </option>
+    <option name="JSON.VALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="6dc2b8" />
+      </value>
+    </option>
+    <option name="JSP_DIRECTIVE_NAME">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JSP_SCRIPTING_BACKGROUND">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+      </value>
+    </option>
+    <option name="KOTLIN_ANNOTATION">
+      <value />
+    </option>
+    <option name="KOTLIN_IMPLICIT_EXHAUSTIVE_WHEN">
+      <value />
+    </option>
+    <option name="KOTLIN_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="c792ea" />
+      </value>
+    </option>
+    <option name="KOTLIN_PROPERTY_WITH_BACKING_FIELD">
+      <value />
+    </option>
+    <option name="KOTLIN_SMART_CAST_RECEIVER">
+      <value />
+    </option>
+    <option name="KOTLIN_SMART_CAST_VALUE">
+      <value />
+    </option>
+    <option name="KOTLIN_SMART_CONSTANT">
+      <value />
+    </option>
+    <option name="LABEL">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="LESS_INJECTED_CODE" />
+    <option baseAttributes="TEXT" name="LESS_JS_CODE_DELIM" />
+    <option name="LESS_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="LINE_FULL_COVERAGE">
+      <value>
+        <option name="BACKGROUND" value="1fc700" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="LINE_NONE_COVERAGE">
+      <value>
+        <option name="BACKGROUND" value="ab1c07" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
+    <option name="LINE_PARTIAL_COVERAGE">
+      <value>
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="LOCAL_VARIABLE_ATTRIBUTES" />
+    <option name="MACRONAME">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="LOG_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ff6b68" />
+      </value>
+    </option>
+    <option name="List/map to object conversion">
+      <value>
+        <option name="FOREGROUND" value="e8bf6a" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="MACRO_PARAMETER" />
+    <option name="MACRONAME">
+      <value>
+        <option name="FOREGROUND" value="908b25" />
+      </value>
+    </option>
+    <option name="MAGIC_MEMBER_ACCESS">
+      <value>
+        <option name="FOREGROUND" value="20c5c3" />
+      </value>
+    </option>
+    <option name="MARKDOWN.AUTO_LINK">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.BULLET_LIST">
+      <value>
+        <option name="FOREGROUND" value="646877" />
+      </value>
+    </option>
+    <option name="MARKDOWN.EXPLICIT_LINK">
+      <value>
+        <option name="FOREGROUND" value="6dc2b8" />
+      </value>
+    </option>
+    <option name="MARKDOWN.HEADER_LEVEL_1">
+      <value>
+        <option name="FOREGROUND" value="63c0ee" />
+      </value>
+    </option>
+    <option name="MARKDOWN.HEADER_LEVEL_2">
+      <value>
+        <option name="FOREGROUND" value="63c0ee" />
+      </value>
+    </option>
+    <option name="MARKDOWN.HEADER_LEVEL_3">
+      <value>
+        <option name="FOREGROUND" value="63c0ee" />
+      </value>
+    </option>
+    <option name="MARKDOWN.HEADER_LEVEL_4">
+      <value>
+        <option name="FOREGROUND" value="63c0ee" />
+      </value>
+    </option>
+    <option name="MARKDOWN.HEADER_LEVEL_5">
+      <value>
+        <option name="FOREGROUND" value="63c0ee" />
+      </value>
+    </option>
+    <option name="MARKDOWN.IMAGE">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.MAIL_LINK">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.REFERENCE_IMAGE">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.REFERENCE_LINK">
+      <value>
+        <option name="FOREGROUND" value="ff355b" />
+      </value>
+    </option>
+    <option name="MARKDOWN.TEXT">
+      <value>
+        <option name="FOREGROUND" value="c3cee3" />
+      </value>
+    </option>
+    <option name="MATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="3a6da0" />
+      </value>
+    </option>
+    <option name="MESSAGE_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="NOT_USED_ELEMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="80807f" />
+      </value>
+    </option>
+    <option name="OC.BADCHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="OC.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option baseAttributes="OC.DOT" name="OC.BRACES" />
+    <option baseAttributes="OC.DOT" name="OC.BRACKETS" />
+    <option baseAttributes="OC.DOT" name="OC.COMMA" />
+    <option name="OC.CPP_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="OC.DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="OC.DOT" />
+    <option name="OC.EXTERN_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="OC.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="OC.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="OC.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="OC.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="OC.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="OC.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="OC.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option baseAttributes="OC.DOT" name="OC.OPERATION_SIGN" />
+    <option name="OC.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option baseAttributes="OC.DOT" name="OC.PARENTHS" />
+    <option name="OC.PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="OC.SELFSUPERTHIS">
+      <value>
+        <option name="FOREGROUND" value="FF5370" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option baseAttributes="OC.DOT" name="OC.SEMICOLON" />
+    <option name="OC.STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="OC.STRUCT_FIELD">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="OC_FORMAT_TOKEN">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="PARAMETER_ATTRIBUTES" />
+    <option name="PHP_CLASS">
+      <value>
+        <option name="FOREGROUND" value="ffcb6b" />
+      </value>
+    </option>
+    <option name="PHP_EXEC_COMMAND_ID">
+      <value>
+        <option name="FOREGROUND" value="a5c25c" />
+        <option name="BACKGROUND" value="252b39" />
+      </value>
+    </option>
+    <option name="PHP_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="2c9ea7" />
+      </value>
+    </option>
+    <option name="PHP_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="ff5370" />
+      </value>
+    </option>
+    <option name="PHP_TAG">
+      <value>
+        <option name="FOREGROUND" value="be2c23" />
+      </value>
+    </option>
+    <option name="PHP_VAR">
+      <value>
+        <option name="FOREGROUND" value="ff5370" />
+      </value>
+    </option>
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+        <option name="BACKGROUND" value="252b39" />
+        <option name="EFFECT_COLOR" value="ff0000" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PROPERTIES.KEY">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="c3cee3" />
+      </value>
+    </option>
+    <option name="PROPERTIES.VALUE">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+      </value>
+    </option>
+    <option name="PROTOCOL_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="PUPPET_BAD_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="PUPPET_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PUPPET_BRACES">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_CLASS">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="PUPPET_COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="PUPPET_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="PUPPET_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_PARENTH">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_REGEX">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="PUPPET_RESOURCE_REFERENCE" />
+    <option name="PUPPET_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_SQ_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="PUPPET_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="PUPPET_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PUPPET_VARIABLE_INTERPOLATION">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="PY.BRACES">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PY.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PY.BUILTIN_NAME">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="PY.CLASS_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="PY.COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PY.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="PY.DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PY.FUNC_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="PY.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="PY.OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="PY.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="PY.STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="PY.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="REGEXP.BRACES">
+      <value>
+        <option name="FOREGROUND" value="2c9ea7" />
+      </value>
+    </option>
+    <option name="REGEXP.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="c792ea" />
+      </value>
+    </option>
+    <option name="REGEXP.CHAR_CLASS">
+      <value>
+        <option name="FOREGROUND" value="6dc2b8" />
+      </value>
+    </option>
+    <option name="REGEXP.ESC_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="c792ea" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REGEXP.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="6dc2b8" />
+        <option name="EFFECT_COLOR" value="bc3f3c" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="REGEXP.META">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REGEXP.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="798194" />
+      </value>
+    </option>
+    <option name="REGEXP.QUOTE_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REST.BOLD">
+      <value>
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="REST.EXPLICIT">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="REST.FIELD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="REST.FIXED">
+      <value>
+        <option name="BACKGROUND" value="48485f" />
+      </value>
+    </option>
+    <option name="REST.INLINE">
+      <value>
+        <option name="BACKGROUND" value="273627" />
+      </value>
+    </option>
+    <option name="REST.INTERPRETED">
+      <value>
+        <option name="BACKGROUND" value="4d5d3d" />
+      </value>
+    </option>
+    <option name="REST.ITALIC">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="REST.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="REST.REF.NAME">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="REST.SECTION.HEADER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="RHTML_COMMENT_ID">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="RHTML_EXPRESSION_END_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RHTML_EXPRESSION_START_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RHTML_OMIT_NEW_LINE_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RHTML_SCRIPTLET_END_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RHTML_SCRIPTLET_START_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_BAD_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="RUBY_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_COLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_COMMA">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="RUBY_CVAR">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_DOT">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_EXPR_IN_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="RUBY_GVAR">
+      <value>
+        <option name="FOREGROUND" value="ff5470" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="RUBY_HASH_ASSOC">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="RUBY_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="RUBY_INTERPOLATED_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option name="RUBY_IVAR">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="RUBY_LINE_CONTINUATION">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_LOCAL_VAR_ID">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="RUBY_METHOD_NAME">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
+    <option name="RUBY_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="RUBY_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_PARAMDEF_CALL">
+      <value>
+        <option name="FOREGROUND" value="82AAFF" />
+      </value>
+    </option>
+    <option name="RUBY_PARAMETER_ID">
+      <value>
+        <option name="FOREGROUND" value="f4e04d" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="RUBY_REGEXP">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="RUBY_SPECIFIC_CALL">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+      </value>
+    </option>
+    <option name="RUBY_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="RUBY_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="52D1DC" />
+      </value>
+    </option>
+    <option name="RUBY_WORDS">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="SASS_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SASS_DEFAULT">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SASS_EXTEND">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SASS_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="SASS_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="SASS_IMPORTANT">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SASS_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SASS_MIXIN">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SASS_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="SASS_PROPERTY_NAME">
+      <value>
+        <option name="FOREGROUND" value="FFCB6B" />
+      </value>
+    </option>
+    <option name="SASS_PROPERTY_VALUE">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="SASS_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="SASS_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="SASS_URL">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="SASS_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="4f4f82" />
+      </value>
+    </option>
+    <option name="SLIM_BAD_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="FF5370" />
+      </value>
+    </option>
+    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_CALL" />
+    <option name="SLIM_CLASS">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="SLIM_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SLIM_DOCTYPE_KWD">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="SLIM_FILTER">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option baseAttributes="SLIM_STATIC_CONTENT" name="SLIM_FILTER_CONTENT" />
+    <option name="SLIM_ID">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="SLIM_INTERPOLATION">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="SLIM_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option baseAttributes="HAML_TEXT" name="SLIM_RUBY_CODE" />
+    <option baseAttributes="TEXT" name="SLIM_STATIC_CONTENT" />
+    <option name="SLIM_STRING_INTERPOLATED">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="SLIM_TAG">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="SLIM_TAG_ATTR_KEY">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="SLIM_TAG_START">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="SPY-JS.EXCEPTION">
+      <value>
+        <option name="BACKGROUND" value="713f3f" />
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+      </value>
+    </option>
+    <option name="SPY-JS.FUNCTION_SCOPE">
+      <value>
+        <option name="BACKGROUND" value="2e2e20" />
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_ONE">
+      <value>
+        <option name="BACKGROUND" value="264226" />
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+      </value>
+    </option>
+    <option name="SPY-JS.PATH_LEVEL_TWO">
+      <value>
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+      </value>
+    </option>
+    <option name="SPY-JS.PROGRAM_SCOPE">
+      <value>
+        <option name="BACKGROUND" value="2b2b2b" />
+        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+      </value>
+    </option>
+    <option baseAttributes="TEXT" name="SPY-JS.VALUE_HINT" />
+    <option name="STATIC_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fda5ff" />
+        <option name="FONT_TYPE" value="3" />
+      </value>
+    </option>
+    <option name="SQL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="SQL_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="f25619" />
+      </value>
+    </option>
+    <option name="SQL_STRING">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="SQL_SYNTHETIC_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+      </value>
+    </option>
+    <option name="STATIC_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="f77669" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="STATIC_METHOD_ATTRIBUTES">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Static property reference ID">
+      <value>
+        <option name="FOREGROUND" value="1a1f29" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TAG_ATTR_KEY">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="TAPESTRY_COMPONENT_TAG">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="bd92ea" />
+      </value>
+    </option>
+    <option name="TEXT">
+      <value>
+        <option name="FOREGROUND" value="eeffff" />
+        <option name="BACKGROUND" value="263238" />
+      </value>
+    </option>
+    <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="5f5f00" />
+        <option name="ERROR_STRIPE_COLOR" value="00ff00" />
+      </value>
+    </option>
+    <option name="TODO_DEFAULT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="c7c7ff" />
+        <option name="FONT_TYPE" value="3" />
+        <option name="ERROR_STRIPE_COLOR" value="ff" />
+      </value>
+    </option>
+    <option name="TYPEDEF">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+      </value>
+    </option>
+    <option name="TYPO">
+      <value>
+        <option name="EFFECT_COLOR" value="ffeb95" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="UNMATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="583535" />
+      </value>
+    </option>
+    <option name="Unresolved reference access">
+      <value>
+        <option name="FOREGROUND" value="808080" />
+        <option name="EFFECT_COLOR" value="808080" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="VELOCITY_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="VELOCITY_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+      </value>
+    </option>
+    <option name="VELOCITY_SCRIPTING_BACKGROUND">
+      <value>
+        <option name="BACKGROUND" value="252b39" />
+      </value>
+    </option>
+    <option name="Valid string escape">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+      </value>
+    </option>
+    <option name="WARNING_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="4a3f10" />
+        <option name="EFFECT_TYPE" value="1" />
+        <option name="EFFECT_COLOR" value="eeffff" />
+        <option name="ERROR_STRIPE_COLOR" value="ffff00" />
+      </value>
+    </option>
+    <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="472c47" />
+        <option name="ERROR_STRIPE_COLOR" value="ffcdff" />
+      </value>
+    </option>
+    <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="623062" />
+      </value>
+    </option>
+    <option name="WRONG_REFERENCES_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="bc3f3c" />
+      </value>
+    </option>
+    <option name="XML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="C792EA" />
+      </value>
+    </option>
+    <option name="XML_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="XML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="F78C6C" />
+      </value>
+    </option>
+    <option name="XML_PROLOGUE">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="XML_TAG">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="XML_TAG_DATA">
+      <value>
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="XML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="XPATH.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="XPATH.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="f25619" />
+      </value>
+    </option>
+    <option name="XPATH.STRING">
+      <value>
+        <option name="FOREGROUND" value="f36e3a" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="XPATH.XPATH_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="f38630" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="YAML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="546E7A" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_DSTRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_KEY">
+      <value>
+        <option name="FOREGROUND" value="f07178" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_LIST">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_STRING">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_VALUE">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="YAML_SIGN">
+      <value>
+        <option name="FOREGROUND" value="89DDFF" />
+      </value>
+    </option>
+    <option name="YAML_TEXT">
+      <value>
+        <option name="FOREGROUND" value="C3E88D" />
+      </value>
+    </option>
+    <option name="osmorc.headerName">
+      <value>
+        <option name="FOREGROUND" value="a7dbd8" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+  </attributes>
 </scheme>

--- a/resources/colors/Material Theme - Lighter.xml
+++ b/resources/colors/Material Theme - Lighter.xml
@@ -579,6 +579,47 @@
                 <option name="FOREGROUND" value="798891"/>
             </value>
         </option>
+        <option name="DJANGO_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="DJANGO_FILTER">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="DJANGO_ID">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="DJANGO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="DJANGO_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="DJANGO_STRING_LITERAL">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="DJANGO_TAG_START_END">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
         <option name="DUPLICATE_FROM_SERVER">
             <value/>
         </option>
@@ -1174,6 +1215,100 @@
                 <option name="FONT_TYPE" value="1"/>
             </value>
         </option>
+        <option name="PY.BRACES">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="PY.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="PY.CLASS_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="FFB62C" />
+            </value>
+        </option>
+        <option name="PY.COMMA">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.DOT">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="PY.FUNC_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="PY.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="E53935" />
+            </value>
+        </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="PY.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="PY.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="PY.PREDEFINED_DEFINITION" />
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="PY.STRING">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="PY.VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
         <option name="REST.FIXED">
             <value>
                 <option name="BACKGROUND" value="252b39"/>
@@ -1189,14 +1324,285 @@
                 <option name="BACKGROUND" value="252b39"/>
             </value>
         </option>
+        <option name="RHTML_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_END_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_START_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RHTML_OMIT_NEW_LINE_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_END_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_START_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_BAD_CHARACTER">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="E53935" />
+            </value>
+        </option>
+        <option name="RUBY_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_COLON">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_COMMA">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="FFB62C" />
+            </value>
+        </option>
+        <option name="RUBY_CVAR">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_DOT">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_EXPR_IN_STRING">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="RUBY_GVAR">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_HASH_ASSOC">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_INTERPOLATED_STRING">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="ffffff" />
+                <option name="BACKGROUND" value="E53935" />
+            </value>
+        </option>
+        <option name="RUBY_IVAR">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="RUBY_LINE_CONTINUATION">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_LOCAL_VAR_ID">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_METHOD_NAME">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option baseAttributes="TEXT" name="RUBY_NTH_REF" />
+        <option name="RUBY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="RUBY_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value>
+                <option name="FOREGROUND" value="6182B8" />
+            </value>
+        </option>
+        <option name="RUBY_PARAMETER_ID">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="RUBY_REGEXP">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="39ADB5" />
+            </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value>
+                <option name="FOREGROUND" value="80CBC4" />
+            </value>
+        </option>
+        <option name="RUBY_STRING">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="RUBY_WORDS">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="SASS_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="CCD7DA" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="SASS_DEFAULT">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="SASS_EXTEND">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="SASS_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
         <option name="SASS_IDENTIFIER">
             <value>
-                <option name="FOREGROUND" value="c2c8d7"/>
+                <option name="FOREGROUND" value="FFB62C" />
+            </value>
+        </option>
+        <option name="SASS_IMPORTANT">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="SASS_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="7C4DFF" />
             </value>
         </option>
         <option name="SASS_MIXIN">
             <value>
-                <option name="FOREGROUND" value="c792ea"/>
+                <option name="FOREGROUND" value="7C4DFF" />
+            </value>
+        </option>
+        <option name="SASS_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="FFB62C" />
+            </value>
+        </option>
+        <option name="SASS_PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="SASS_STRING">
+            <value>
+                <option name="FOREGROUND" value="91B859" />
+            </value>
+        </option>
+        <option name="SASS_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="FF5370" />
+            </value>
+        </option>
+        <option name="SASS_URL">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
+            </value>
+        </option>
+        <option name="SASS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="F76D47" />
             </value>
         </option>
         <option name="SEARCH_RESULT_ATTRIBUTES">


### PR DESCRIPTION
These are missing and as a result IDEA falls back onto default colors which look terrible. I've added these in so it should look much better for people using RubyMine and PyCharm.