### PR TITLE
More sensible colors for diffs

### DIFF
--- a/src/main/resources/colors/Material Theme - Default.xml
+++ b/src/main/resources/colors/Material Theme - Default.xml
@@ -559,25 +559,25 @@
         </option>
         <option name="DIFF_CONFLICT">
             <value>
-                <option name="BACKGROUND" value="b03435" />
+                <option name="BACKGROUND" value="4b1515" />
                 <option name="ERROR_STRIPE_COLOR" value="b03435" />
             </value>
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="BACKGROUND" value="656e76" />
+                <option name="BACKGROUND" value="41454b" />
                 <option name="ERROR_STRIPE_COLOR" value="656e76" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="BACKGROUND" value="447152" />
+                <option name="BACKGROUND" value="264b33" />
                 <option name="ERROR_STRIPE_COLOR" value="447152" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="43698d" />
+                <option name="BACKGROUND" value="12404b" />
                 <option name="ERROR_STRIPE_COLOR" value="43698d" />
             </value>
         </option>


### PR DESCRIPTION
[This](https://github.com/ChrisRM/material-theme-jetbrains/pull/208) was a good change, but the colors are too bright and interfere an actual code, especially comments become barely visible.
![Imgur](http://i.imgur.com/KrIkbWQ.png)

I suggest a little improvement to make them less bright. All changes and conflicts are still visible and the code becomes clean too.
![Imgur](http://i.imgur.com/q13FQvT.png)
