### PR TITLE
Issue #258 fix crashes on Windows for IntelliJ IDEA 2016.3

### DIFF
--- a/src/main/resources/com/chrisrm/idea/mt.darker_windows.properties
+++ b/src/main/resources/com/chrisrm/idea/mt.darker_windows.properties
@@ -8,8 +8,3 @@ MenuBar.border=com.intellij.ide.ui.laf.darcula.ui.DarculaMenuBarBorder
 InternalFrameUI=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalFrameUI
 InternalFrame.border=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalBorder
 RootPaneUI=com.intellij.ide.ui.laf.darcula.ui.DarculaRootPaneUI
-
-InternalFrame.closeIcon=AllIcons.Windows.Close
-InternalFrame.iconifyIcon=AllIcons.Windows.Iconify
-InternalFrame.maximizeIcon=AllIcons.Windows.Maximize
-InternalFrame.minimizeIcon=AllIcons.Windows.Minimize

--- a/src/main/resources/com/chrisrm/idea/mt.default_windows.properties
+++ b/src/main/resources/com/chrisrm/idea/mt.default_windows.properties
@@ -8,8 +8,3 @@ MenuBar.border=com.intellij.ide.ui.laf.darcula.ui.DarculaMenuBarBorder
 InternalFrameUI=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalFrameUI
 InternalFrame.border=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalBorder
 RootPaneUI=com.intellij.ide.ui.laf.darcula.ui.DarculaRootPaneUI
-
-InternalFrame.closeIcon=AllIcons.Windows.Close
-InternalFrame.iconifyIcon=AllIcons.Windows.Iconify
-InternalFrame.maximizeIcon=AllIcons.Windows.Maximize
-InternalFrame.minimizeIcon=AllIcons.Windows.Minimize

--- a/src/main/resources/com/chrisrm/idea/mt.lighter_windows.properties
+++ b/src/main/resources/com/chrisrm/idea/mt.lighter_windows.properties
@@ -8,8 +8,3 @@ MenuBar.border=com.intellij.ide.ui.laf.darcula.ui.DarculaMenuBarBorder
 InternalFrameUI=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalFrameUI
 InternalFrame.border=com.intellij.ide.ui.laf.darcula.ui.DarculaInternalBorder
 RootPaneUI=com.intellij.ide.ui.laf.darcula.ui.DarculaRootPaneUI
-
-InternalFrame.closeIcon=AllIcons.Windows.Close
-InternalFrame.iconifyIcon=AllIcons.Windows.Iconify
-InternalFrame.maximizeIcon=AllIcons.Windows.Maximize
-InternalFrame.minimizeIcon=AllIcons.Windows.Minimize


### PR DESCRIPTION
I removed frame icons completely. They don't make any sense.