### PR TITLE
Fixe for #272 by removing iconProvider extension

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -69,7 +69,6 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <editorTabColorProvider implementation="com.chrisrm.idea.MTEditorTabColor"/>
-        <iconProvider implementation="com.chrisrm.idea.icons.MTFileIconProvider"/>
         <bundledColorScheme path="/colors/Material Theme - Lighter"/>
         <bundledColorScheme path="/colors/Material Theme - Default"/>
         <bundledColorScheme path="/colors/Material Theme - Darker"/>


### PR DESCRIPTION
With the new release on Idea Community EAP the method icons are not shown in different views. Instead the java logo icon is shown. Removing the iconProvider extension point definition from the plugin.xml seems to enable the method icons back.