### PR TITLE
Adds '.yaml' as valid file extension for YAML file icon

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -19,7 +19,7 @@
         <regex name="HTML" pattern=".*\.(html|xhtml|tpl)$" icon="/icons/fileTypes/html.png"/>
         <regex name="AppleScript" pattern=".*\.applescript$" icon="/icons/fileTypes/applescript.png"/>
         <regex name="Perl" pattern=".*\.pl$" icon="/icons/fileTypes/perl.png"/>
-        <regex name="YAML" pattern=".*\.(yml|config|info)$" icon="/icons/fileTypes/yaml.png"/>
+        <regex name="YAML" pattern=".*\.(yml|yaml|config|info)$" icon="/icons/fileTypes/yaml.png"/>
         <regex name="Photoshop" pattern=".*\.psd$" icon="/icons/fileTypes/psd.png"/>
         <regex name="Illustrator" pattern=".*\.ai$" icon="/icons/fileTypes/ai.png"/>
         <regex name="ActionScript" pattern=".*\.as$" icon="/icons/fileTypes/actionscript.png"/>


### PR DESCRIPTION
Currently `.yaml` files show up without a file icon.
![yaml-icon](https://cloud.githubusercontent.com/assets/14163530/22122422/d3bbb740-de7f-11e6-8c26-c41581b43408.png)

The official docs for YAML recommend the `.yaml` extension, so I've added this to the YAML line of the `icon_associations.xml`.