### PR TITLE
Add optional .json extension to babelrc

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -47,7 +47,7 @@
         <regex name="AppleScript" pattern=".*\.applescript$" icon="/icons/files/applescript.png"/>
         <regex name="ASP" pattern=".*\.(asp|aspx|cshtml)$" icon="/icons/files/asp.png"/>
         <regex name="Aurelia" pattern="aurelia(file)?\.js(on)?" icon="/icons/files/aurelia.png"/>
-        <regex name="Babel" pattern=".*\.(babelrc)$" icon="/icons/files/babel.png"/>
+        <regex name="Babel" pattern=".*\.(babelrc)(.json)?$" icon="/icons/files/babel.png"/>
         <regex name="Bazel" pattern=".*\.(bzl)$" icon="/icons/files/bazel.png"/>
         <regex name="Behat" pattern=".*\.feature$" icon="/icons/files/behat.png"/>
         <regex name="Blade" pattern=".*\.blade\.php$" icon="/icons/files/blade.png"/>


### PR DESCRIPTION
It is allowed to name `.babelrc.json`. Just wanted to bring the theme up-to-date.

#### Description
Adapt allowed naming format.

#### Motivation and Context
I want my IDE to look nice.

#### How Has This Been Tested?
I tested the regex for both possibilites `.babelrc` and `.babelrc.json`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.