### PR TITLE
directory icon optimization

### DIFF
--- a/src/main/java/com/chrisrm/idea/icons/MTFileIconProvider.java
+++ b/src/main/java/com/chrisrm/idea/icons/MTFileIconProvider.java
@@ -57,8 +57,24 @@ import javax.swing.*;
  * Provider for file icons
  */
 public final class MTFileIconProvider extends IconProvider {
-
   private final Associations associations = Associations.AssociationsFactory.create();
+  private boolean hasJFS;
+  private boolean hasJDS;
+  {
+    try {
+      Class.forName("com.intellij.openapi.vfs.jrt.JrtFileSystem");
+      hasJFS = true;
+    } catch (final ClassNotFoundException e) {
+      hasJFS = false;
+    }
+    try {
+      Class.forName("com.intellij.psi.JavaDirectoryService");
+      hasJDS = true;
+    } catch (final ClassNotFoundException e) {
+      hasJDS = false;
+    }
+  }
+
 
   @Nullable
   @Override
@@ -96,22 +112,6 @@ public final class MTFileIconProvider extends IconProvider {
 
     final SourceFolder sourceFolder;
     Icon symbolIcon = null;
-
-    boolean hasJFS;
-    try {
-      Class.forName("com.intellij.openapi.vfs.jrt.JrtFileSystem");
-      hasJFS = true;
-    } catch (final ClassNotFoundException e) {
-      hasJFS = false;
-    }
-
-    boolean hasJDS;
-    try {
-      Class.forName("com.intellij.psi.JavaDirectoryService");
-      hasJDS = true;
-    } catch (final ClassNotFoundException e) {
-      hasJDS = false;
-    }
 
     if (vFile.getParent() == null && vFile.getFileSystem() instanceof ArchiveFileSystem) {
       symbolIcon = PlatformIcons.JAR_ICON;


### PR DESCRIPTION
According to snapshots in https://youtrack.jetbrains.com/issue/WEB-29182 constant Class.forName could be the problem.
Looks like result can be stored in the provider and reused