### PR TITLE
Adds icon association for cfg files

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -249,7 +249,7 @@
 
         <regex name="Yarn" pattern="(.*yarn\.lock$|.*\.yarnclean$)" icon="/icons/files/yarn.png"/>
         <!-- These take the least priority -->
-        <regex name="Preferences" pattern=".*\.(ini|config|env)$" icon="/icons/files/preferences.png"/>
+        <regex name="Preferences" pattern=".*\.(ini|config|cfg|env)$" icon="/icons/files/preferences.png"/>
         <regex name="Binary" pattern="^[^.]+$" icon="/icons/files/binary.png"/>
 
         <regex name="Font" pattern=".*\.(ttf|ttc|pfb|pfm|otf|dfont|pfa|afm|eot|woff2?)$"


### PR DESCRIPTION
#### Description
Adds cfg as a valid icon association, using the same icon as .ini and .config files. 

#### Motivation and Context
I noticed a cfg file in my project was using an icon which was not in keeping with the theme, because the file type did not have an association set.

#### How Has This Been Tested?
No impact to any other aspect of the code.
Not specifically tested, as it's just updating a file type association (made a couple of these changes before so I'm content it will work). 

#### Screenshots (if appropriate):
N/A

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.