### PR TITLE
Increase max tree indent to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Panel Settings:
 - *Monochrome Icons*: Filter all icons with the current theme's primary color.
 - *Hide Icons*: Hide file icons (you must have Material Icons options on)
 - *Custom Sidebar Height*: Set custom line height in Project View (min: 18, max: 30)
-- *Custom Tree Indent*: Increase or reduce indentation in the sidebar (min: 2, max: 8)
+- *Custom Tree Indent*: Increase or reduce indentation in the sidebar (min: 2, max: 20)
 - *Bold directories*: Set bold font weight for directories in the Project View
 - *Compact Status Bar*: Reduce the height of the status bar (this is the default height)
 - *Compact Table Cells*: Reduce the height of table headers and cells

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Panel Settings:
 - *Monochrome Icons*: Filter all icons with the current theme's primary color.
 - *Hide Icons*: Hide file icons (you must have Material Icons options on)
 - *Custom Sidebar Height*: Set custom line height in Project View (min: 18, max: 30)
-- *Custom Tree Indent*: Increase or reduce indentation in the sidebar (min: 2, max: 20)
+- *Custom Tree Indent*: Increase or reduce indentation in the sidebar (min: 0, max: 20)
 - *Bold directories*: Set bold font weight for directories in the Project View
 - *Compact Status Bar*: Reduce the height of the status bar (this is the default height)
 - *Compact Table Cells*: Reduce the height of table headers and cells

--- a/src/main/java/com/chrisrm/idea/MTConfig.java
+++ b/src/main/java/com/chrisrm/idea/MTConfig.java
@@ -57,7 +57,7 @@ public class MTConfig implements PersistentStateComponent<MTConfig> {
   public static final int MIN_HIGHLIGHT_THICKNESS = 1;
   public static final int MAX_TABS_HEIGHT = 60;
   public static final int MIN_TABS_HEIGHT = 18;
-  public static final int MAX_TREE_INDENT = 10;
+  public static final int MAX_TREE_INDENT = 20;
   public static final int MIN_TREE_INDENT = 0;
   public static final int MAX_SIDEBAR_HEIGHT = 36;
   public static final int MIN_SIDEBAR_HEIGHT = 18;


### PR DESCRIPTION
Increase maximum value for tree indentation to 20.

#### Description
Increase maximum value for tree indentation to 20, so we can add some more space between the folder-arrow and -icon.

#### Motivation and Context
Fixes #697. IMO the folder-arrow and -icon are too close together, even when set to the maximum of 10. Allowing to set it to max 20 should give some room for breathing.

#### How Has This Been Tested?
To be honest, I didn't test this :innocent: 

#### Screenshots (if appropriate):
See  #697.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It can be a bug-fix or a feature, depending how you look at it :wink: 

#### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.