### PR TITLE
Add HighContrast variant of Material Lighter editor color scheme (#783)

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -77,6 +77,7 @@
         <iconProvider implementation="com.chrisrm.idea.icons.MTFileIconProvider" order="first"/>
 
         <bundledColorScheme path="/colors/Material Lighter"/>
+        <bundledColorScheme path="/colors/Material Lighter HighContrast"/>
         <bundledColorScheme path="/colors/Material Oceanic"/>
         <bundledColorScheme path="/colors/Material Palenight"/>
         <bundledColorScheme path="/colors/Material Darker"/>

--- a/src/main/resources/colors/Material Lighter HighContrast.xml
+++ b/src/main/resources/colors/Material Lighter HighContrast.xml
@@ -1,0 +1,3612 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2018 Chris Magnussen, Elior Boukhobza and Maxr1998
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  ~
+  ~
+  -->
+
+<scheme name="Material Lighter HighContrast" version="142">
+    <option name="FONT_SCALE" value="1.0"/>
+    <metaInfo>
+        <property name="created">2017-04-10T18:10:53</property>
+        <property name="ide">idea</property>
+        <property name="ideVersion">2017.1.1.0.0</property>
+        <property name="modified">2018-05-21T19:46:17</property>
+        <property name="originalScheme">Material Theme - Lighter (HighContrast)</property>
+    </metaInfo>
+    <option name="LINE_SPACING" value="1.4"/>
+    <font>
+        <option name="EDITOR_FONT_NAME" value="Fira Code"/>
+        <option name="EDITOR_FONT_SIZE" value="12"/>
+    </font>
+    <font>
+        <option name="EDITOR_FONT_NAME" value="Source Code Pro"/>
+        <option name="EDITOR_FONT_SIZE" value="12"/>
+    </font>
+    <option name="CONSOLE_FONT_NAME" value="Menlo"/>
+    <option name="CONSOLE_LINE_SPACING" value="1.4"/>
+    <colors>
+        <option name="ADDED_LINES_COLOR" value="00c853"/>
+        <option name="ANNOTATIONS_COLOR" value="424242"/>
+        <option name="CARET_COLOR" value="ffcc00"/>
+        <option name="CARET_ROW_COLOR" value="f5f5f5"/>
+        <option name="CONSOLE_BACKGROUND_KEY" value="fafafa"/>
+        <option name="DELETED_LINES_COLOR" value="d50000"/>
+        <option name="DOCUMENTATION_COLOR" value="f3f5f6"/>
+        <option name="FILESTATUS_ADDED" value="91B859"/>
+        <option name="FILESTATUS_COPIED" value="91B859"/>
+        <option name="FILESTATUS_DELETED" value="808080"/>
+        <option name="FILESTATUS_HIJACKED" value="ffa000"/>
+        <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="808080"/>
+        <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="ab7967"/>
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="d5756c"/>
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="d5756c"/>
+        <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="d5756c"/>
+        <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="91b859"/>
+        <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="ab7967"/>
+        <option name="FILESTATUS_MERGED" value="311b92"/>
+        <option name="FILESTATUS_MODIFIED" value="80cbc4"/>
+        <!--<option name="FILESTATUS_NOT_CHANGED" value="626669"/>-->
+        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80cbc4"/>
+        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80cbc4"/>
+        <option name="FILESTATUS_SWITCHED" value="311b92"/>
+        <option name="FILESTATUS_SUPPRESSED" value="666666"/>
+        <option name="FILESTATUS_UNKNOWN" value="f77669"/>
+        <option name="FILESTATUS_addedOutside" value="91b859"/>
+        <option name="FILESTATUS_changelistConflict" value="d5756c"/>
+        <option name="FILESTATUS_modifiedOutside" value="1565c0"/>
+        <option name="GUTTER_BACKGROUND" value="fafafa"/>
+        <option name="INDENT_GUIDE" value="e0e0e0"/>
+        <option name="INFORMATION_HINT" value="f3f5f6"/>
+        <option name="LINE_NUMBERS_COLOR" value="666666"/>
+        <option name="METHOD_SEPARATORS_COLOR" value="666666"/>
+        <option name="MODIFIED_LINES_COLOR" value="ffd600"/>
+        <option name="MT_ADDED" value="91b859"/>
+        <option name="MT_DELETED" value="e65100"/>
+        <option name="MT_HIJACKED" value="ffa000"/>
+        <option name="MT_IDEA_FILESTATUS_IGNORED" value="ab7967"/>
+        <option name="MT_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="e53935"/>
+        <option name="MT_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="e53935"/>
+        <option name="MT_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="e53935"/>
+        <option name="MT_IGNORE.PROJECT_VIEW.IGNORED" value="ab7967"/>
+        <option name="MT_MERGED" value="945eb8"/>
+        <option name="MT_MODIFIED" value="00897b"/>
+        <option name="MT_NOT_CHANGED" value="424242"/>
+        <option name="MT_NOT_CHANGED_IMMEDIATE" value="00897b"/>
+        <option name="MT_NOT_CHANGED_RECURSIVE" value="00897b"/>
+        <option name="MT_OBSOLETE" value="ffa000"/>
+        <option name="MT_SUPPRESSED" value="424242"/>
+        <option name="MT_SWITCHED" value="e65100"/>
+        <option name="MT_UNKNOWN" value="e53935"/>
+        <option name="MT_modifiedOutside" value="1565c0"/>
+        <option name="NOTIFICATION_BACKGROUND" value="3d1a11"/>
+        <option name="NOT_CHANGED" value="a7adb0"/>
+        <option name="QUESTION_HINT" value="f3f5f6"/>
+        <option name="READONLY_FRAGMENT_BACKGROUND" value=""/>
+        <option name="RECURSIVE_CALL_ATTRIBUTES" value="574300"/>
+        <option name="RIGHT_MARGIN_COLOR" value="e7eaec"/>
+        <option name="SELECTED_INDENT_GUIDE" value="8c8c8c"/>
+        <option name="SELECTED_TEARLINE_COLOR" value="666666"/>
+        <option name="SELECTION_BACKGROUND" value="eeeeee"/>
+        <option name="SELECTION_FOREGROUND" value="212121"/>
+        <option name="SOFT_WRAP_SIGN_COLOR" value="4f6269"/>
+        <option name="TEARLINE_COLOR" value="eeeeee"/>
+        <option name="TOOLTIP" value="fafafa"/>
+        <option name="VCS_ANNOTATIONS_COLOR_1" value="a7fff8"/>
+        <option name="VCS_ANNOTATIONS_COLOR_2" value="8cdcd5"/>
+        <option name="VCS_ANNOTATIONS_COLOR_3" value="ffffff"/>
+        <option name="VCS_ANNOTATIONS_COLOR_4" value="ff0a79"/>
+        <option name="VCS_ANNOTATIONS_COLOR_5" value="311b92"/>
+        <option name="WHITESPACES" value="cfd8dc"/>
+    </colors>
+    <attributes>
+        <option name="ABSTRACT_CLASS_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="ANNOTATION_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="APACHE_CONFIG.ARG_LEXEM">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="APACHE_CONFIG.COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="APACHE_CONFIG.IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Abstract class name">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="Annotation">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="Anonymous class name">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="Anotation attribute name">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Bad character">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Block comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Braces">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Brackets">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="BASH.EXTERNAL_COMMAND">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="BASH.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+        <option name="BASH.FUNCTION_DEF_NAME" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING"/>
+        <option name="BASH.INTERNAL_COMMAND" baseAttributes="BASH.EXTERNAL_COMMAND"/>
+        <option name="BASH.REDIRECTION" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT"/>
+        <option name="BLADE_BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="BLADE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="BLADE_DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="BLADE_TEXT_BLOCK_BOUNDARY">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="BNF_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="1a1f29"/>
+            </value>
+        </option>
+        <option name="BNF_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f36e3a"/>
+            </value>
+        </option>
+        <option name="BOOKMARKS_ATTRIBUTES">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="ERROR_STRIPE_COLOR" value="dbdbdb"/>
+            </value>
+        </option>
+        <option name="BROWSEWORDATCARET">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="EFFECT_COLOR" value="000000"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="BREADCRUMBS_CURRENT">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+                <option name="BACKGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="BREADCRUMBS_DEFAULT">
+            <value>
+                <option name="FOREGROUND" value="b0bec4"/>
+                <option name="BACKGROUND" value="fafafa"/>
+            </value>
+        </option>
+        <option name="BREADCRUMBS_HOVERED">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+                <option name="BACKGROUND" value="3F51B5"/>
+            </value>
+        </option>
+        <option name="BREADCRUMBS_INACTIVE">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="BACKGROUND" value="fafafa"/>
+            </value>
+        </option>
+        <option name="BREAKPOINT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="BROWSEWORDATCARET">
+            <value>
+                <option name="FOREGROUND" value="3F51B5"/>
+                <option name="EFFECT_COLOR" value="3F51B5"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="Bad character">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Block comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Braces">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Brackets">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="1a1f29"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.COLON">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
+            <value/>
+        </option>
+        <option name="COFFEESCRIPT.EXISTENTIAL">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.FUNCTION_NAME">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
+            <value/>
+        </option>
+        <option name="COFFEESCRIPT.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="COFFEESCRIPT.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="CONDITIONALLY_NOT_COMPILED">
+            <value>
+                <option name="FOREGROUND" value="536c46"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="7eaef1"/>
+            </value>
+        </option>
+        <option name="CONSOLE_BLUE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="5394ec"/>
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="6cdada"/>
+            </value>
+        </option>
+        <option name="CONSOLE_CYAN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="33cccc"/>
+            </value>
+        </option>
+        <option name="CONSOLE_ERROR_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GRAY_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="999999"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="70ff70"/>
+            </value>
+        </option>
+        <option name="CONSOLE_GREEN_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="7f00"/>
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff99ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_MAGENTA_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff70ff"/>
+            </value>
+        </option>
+        <option name="CONSOLE_NORMAL_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="CONSOLE_OUTPUT">
+            <value>
+                <option name="BACKGROUND" value="252b39"/>
+            </value>
+        </option>
+        <option name="CONSOLE_RANGE_TO_EXECUTE">
+            <value/>
+        </option>
+        <option name="CONSOLE_RED_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff8785"/>
+            </value>
+        </option>
+        <option name="CONSOLE_RED_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff6b68"/>
+            </value>
+        </option>
+        <option name="CONSOLE_SYSTEM_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="CONSOLE_USER_INPUT">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="CONSOLE_WHITE_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="f8f8f0"/>
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ffff00"/>
+            </value>
+        </option>
+        <option name="CONSOLE_YELLOW_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="cdcd00"/>
+            </value>
+        </option>
+        <option name="CSS.COLOR">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="CSS.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="CSS.HASH">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="CSS.IDENT">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="CSS.PROPERTY_NAME">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="CSS.PROPERTY_VALUE">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="CSS.PSEUDO">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="CSS.TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="CSS.UNICODE.RANGE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="CTRL_CLICKABLE">
+            <value>
+                <option name="FOREGROUND" value="3F51B5"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE"/>
+        <option name="CUSTOM_KEYWORD1_ATTRIBUTES" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ab51ba"/>
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="f9795"/>
+            </value>
+        </option>
+        <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="c93b48"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="Class">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES" baseAttributes="DEFAULT_LINE_COMMENT"/>
+        <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES" baseAttributes="DEFAULT_BLOCK_COMMENT"/>
+        <option name="CUSTOM_NUMBER_ATTRIBUTES" baseAttributes="DEFAULT_NUMBER"/>
+        <option name="CUSTOM_STRING_ATTRIBUTES" baseAttributes="DEFAULT_STRING"/>
+        <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES" baseAttributes="DEFAULT_VALID_STRING_ESCAPE"/>
+        <option name="DEFAULT_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="DEFAULT_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOC_MARKUP">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="DEFAULT_DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_FUNCTION_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INSTANCE_FIELD">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INTERFACE_NAME">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="DEFAULT_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="EFFECT_COLOR" value="722c40"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LABEL" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="DEFAULT_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="DEFAULT_METADATA">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="DEFAULT_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="DEFAULT_PREDEFINED_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_FIELD">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STATIC_METHOD">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="DEFAULT_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="DEFAULT_TAG">
+            <value>
+                <option name="FOREGROUND" value="FF5370"/>
+            </value>
+        </option>
+        <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
+            <value/>
+        </option>
+        <option name="DEFAULT_VALID_STRING_ESCAPE">
+            <value/>
+        </option>
+        <option name="DELETED_TEXT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="EFFECT_COLOR" value="c14360"/>
+                <option name="EFFECT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="DEPRECATED_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="000000"/>
+                <option name="EFFECT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="DIFF_CONFLICT">
+            <value>
+                <option name="FOREGROUND" value="b09bff"/>
+                <option name="BACKGROUND" value="311b92"/>
+                <option name="ERROR_STRIPE_COLOR" value="8f5247"/>
+            </value>
+        </option>
+        <option name="DIFF_DELETED">
+            <value>
+                <option name="FOREGROUND" value="f2adab"/>
+                <option name="BACKGROUND" value="e53935"/>
+                <option name="ERROR_STRIPE_COLOR" value="656e76"/>
+            </value>
+        </option>
+        <option name="DIFF_INSERTED">
+            <value>
+                <option name="BACKGROUND" value="91b859"/>
+                <option name="ERROR_STRIPE_COLOR" value="447152"/>
+            </value>
+        </option>
+        <option name="DIFF_MODIFIED">
+            <value>
+                <option name="BACKGROUND" value="ffa000"/>
+                <option name="ERROR_STRIPE_COLOR" value="43698d"/>
+            </value>
+        </option>
+        <option name="DUPLICATE_FROM_SERVER">
+            <value/>
+        </option>
+        <option name="ELIXIR_ALIAS" baseAttributes="DEFAULT_CLASS_NAME"/>
+        <option name="ELIXIR_BIT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="ELIXIR_BRACES" baseAttributes="DEFAULT_BRACES"/>
+        <option name="ELIXIR_BRACKET" baseAttributes="DEFAULT_BRACKETS"/>
+        <option name="ELIXIR_CALLBACK" baseAttributes="ELIXIR_SPECIFICATION"/>
+        <option name="ELIXIR_CHAR_LIST" baseAttributes="DEFAULT_STRING"/>
+        <option name="ELIXIR_CHAR_TOKEN" baseAttributes="DEFAULT_ENTITY"/>
+        <option name="ELIXIR_DOT" baseAttributes="DEFAULT_DOT"/>
+        <option name="ELIXIR_EXPRESSION_SUBSTITUTION_MARK" baseAttributes="DEFAULT_BRACES"/>
+        <option name="ELIXIR_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+        <option name="ELIXIR_IGNORED_VARIABLE" baseAttributes="ELIXIR_VARIABLE"/>
+        <option name="ELIXIR_MACRO_CALL" baseAttributes="ELIXIR_FUNCTION_CALL"/>
+        <option name="ELIXIR_MAP" baseAttributes="DEFAULT_BRACES"/>
+        <option name="ELIXIR_OPERATION_SIGN" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="ELIXIR_PARAMETER" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="ELIXIR_PARENTHESES" baseAttributes="DEFAULT_PARENTHS"/>
+        <option name="ELIXIR_PREDEFINED" baseAttributes="DEFAULT_PREDEFINED_SYMBOL"/>
+        <option name="ELIXIR_SIGIL" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR"/>
+        <option name="ELIXIR_SPECIFICATION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="ELIXIR_STRING" baseAttributes="DEFAULT_STRING"/>
+        <option name="ELIXIR_STRUCT" baseAttributes="ELIXIR_MAP"/>
+        <option name="ELIXIR_TYPE" baseAttributes="DEFAULT_METADATA"/>
+        <option name="ELIXIR_TYPE_PARAMETER" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="ELIXIR_VALID_ESCAPE_SEQUENCE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE"/>
+        <option name="ELIXIR_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
+        <option name="ELM_ARROW" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="ELM_BRACES" baseAttributes="DEFAULT_BRACES"/>
+        <option name="ELM_BRACKETS" baseAttributes="DEFAULT_BRACKETS"/>
+        <option name="ELM_COMMA" baseAttributes="DEFAULT_COMMA"/>
+        <option name="ELM_DEFINITION_NAME" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="ELM_EQ" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="ELM_OPERATOR" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="ELM_PARENTHESIS" baseAttributes="DEFAULT_PARENTHS"/>
+        <option name="ELM_PIPE" baseAttributes="DEFAULT_OPERATION_SIGN"/>
+        <option name="ELM_TYPE" baseAttributes="DEFAULT_CLASS_NAME"/>
+        <option name="ELM_TYPE_ANNOTATION_NAME" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="ELM_TYPE_ANNOTATION_SIGNATURE_TYPES" baseAttributes="DEFAULT_CLASS_REFERENCE"/>
+        <option name="ENUM_CONST">
+            <value>
+                <option name="FOREGROUND" value="9373a5"/>
+            </value>
+        </option>
+        <option name="ERL_ATOM" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="ERL_MACRO" baseAttributes="DEFAULT_STATIC_FIELD"/>
+        <option name="ERL_RECORDS" baseAttributes="DEFAULT_INSTANCE_FIELD"/>
+        <option name="ERL_VARIABLES" baseAttributes="DEFAULT_GLOBAL_VARIABLE"/>
+        <option name="ERRORS_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="ERROR_STRIPE_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="4"/>
+            </value>
+        </option>
+        <option name="EXECUTIONPOINT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Enum name">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="FOLDED_TEXT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="EFFECT_COLOR" value="311b92"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+            <value>
+                <option name="EFFECT_COLOR" value="f49810"/>
+                <option name="ERROR_STRIPE_COLOR" value="f49810"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GHERKIN_REGEXP_PARAMETER" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="GROOVY_KEYWORD" baseAttributes="JAVA_KEYWORD"/>
+        <option name="GO_BAD_TOKEN">
+            <value>
+                <option name="EFFECT_COLOR" value="e889b5"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GO_BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GO_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_BRACKET">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_TYPE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="GO_BUILTIN_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_COLON">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="GO_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_COMMENT_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GO_DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_EXPORTED_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="GO_FUNCTION_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GO_LABEL">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="808080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="GO_LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="GO_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_METHOD_RECEIVER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_OPERATOR">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE_EXPORTED_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE_LOCAL_STRUCT">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="GO_PACKAGE_LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_PARENTHESES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="GO_SCOPE_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="GO_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="GO_STRUCT_EXPORTED_MEMBER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_STRUCT_LOCAL_MEMBER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="GO_TYPE_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="GO_TYPE_SPECIFICATION">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="HOCON_BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_BOOLEAN">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_DOUBLE_SLASH_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_HASH_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_INCLUDE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_INCLUDE_MODIFIER_PARENS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_INVALID_STRING_ESCAPE">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_KEY_VALUE_SEPARATOR">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_MULTILINE_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="HOCON_NULL">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HOCON_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="HOCON_OBJECT_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_OPTIONAL_SUBSTITUTION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_QUOTED_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="HOCON_SUBSTITUTION_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_SUBSTITUTION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="HOCON_UNQUOTED_STRING">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="HOCON_VALID_STRING_ESCAPE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_NAME">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="HTML_ATTRIBUTE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="HTML_ENTITY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="HTML_TAG">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8"/>
+            </value>
+        </option>
+        <option name="HTML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="ff5370"/>
+            </value>
+        </option>
+        <option name="HYPERLINK_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="EFFECT_COLOR" value="00897b"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="424242"/>
+                <option name="ERROR_STRIPE_COLOR" value="65737e"/>
+            </value>
+        </option>
+        <option name="IGNORE.BRACKET" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="IGNORE.COMMENT" baseAttributes="DEFAULT_LINE_COMMENT"/>
+        <option name="IGNORE.HEADER" baseAttributes="DEFAULT_DOC_COMMENT_TAG"/>
+        <option name="IGNORE.NEGATION" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="IGNORE.SECTION" baseAttributes="DEFAULT_DOC_COMMENT"/>
+        <option name="IGNORE.SLASH" baseAttributes="DEFAULT_COMMA"/>
+        <option name="IGNORE.SYNTAX" baseAttributes="DEFAULT_INSTANCE_FIELD"/>
+        <option name="IGNORE.VALUE" baseAttributes="DEFAULT_STRING"/>
+        <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="INFO_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="91b859"/>
+                <option name="ERROR_STRIPE_COLOR" value="aeae80"/>
+                <option name="EFFECT_TYPE" value="4"/>
+            </value>
+        </option>
+        <option name="INJECTED_LANGUAGE_FRAGMENT">
+            <value/>
+        </option>
+        <option name="INLINE_PARAMETER_HINT">
+            <value>
+                <option name="FOREGROUND" value="546E7A"/>
+                <option name="BACKGROUND" value="F4F4F4"/>
+            </value>
+        </option>
+        <option name="INLINE_PARAMETER_HINT_CURRENT">
+            <value>
+                <option name="FOREGROUND" value="ffffff"/>
+                <option name="BACKGROUND" value="3F51B5"/>
+            </value>
+        </option>
+        <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+            <value>
+                <option name="FOREGROUND" value="546E7A"/>
+                <option name="BACKGROUND" value="D2D4D5"/>
+            </value>
+        </option>
+        <option name="INSTANCE_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="IVAR">
+            <value>
+                <option name="FOREGROUND" value="9373a5"/>
+            </value>
+        </option>
+        <option name="Implicit conversion">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Instance field">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Instance property reference ID">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Interface name">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Invalid string escape">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JADE_FILE_PATH" baseAttributes="DEFAULT_STRING"/>
+        <option name="JADE_FILTER_NAME" baseAttributes="DEFAULT_LABEL"/>
+        <option name="JADE_JS_BLOCK" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="JADE_STATEMENTS" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JFLEX_MACROS_REF">
+            <value>
+                <option name="FOREGROUND" value="1a1f29"/>
+            </value>
+        </option>
+        <option name="JS.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="JS.BADCHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.BRACES">
+            <value>
+                <option name="FOREGROUND" value="aab564"/>
+            </value>
+        </option>
+        <option name="JS.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.CLASS">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="JS.COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="JS.DOC_MARKUP">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="JS.DOC_TAG">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JS.DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.FUNCTION_ARROW">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.GLOBAL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="JS.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="JS.INSTANCE_MEMBER_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="JS.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.LABEL">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="808080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JS.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JS.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="JS.MODULE_NAME">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="JS.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="JS.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="JS.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="JS.REGEXP">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="JS.SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="JS.STATIC_MEMBER_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="JS.STATIC_MEMBER_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="JSP_DIRECTIVE_NAME">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="JSP_SCRIPTING_BACKGROUND">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8"/>
+            </value>
+        </option>
+        <option name="KOTLIN_ANNOTATION">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
+            <value/>
+        </option>
+        <option name="KOTLIN_FUNCTION_LITERAL_BRACES_AND_ARROW">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="KOTLIN_LABEL" baseAttributes="DEFAULT_LABEL"/>
+        <option name="KOTLIN_NAMED_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="LABEL">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="LINE_FULL_COVERAGE">
+            <value>
+                <option name="BACKGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="LINE_NONE_COVERAGE">
+            <value>
+                <option name="BACKGROUND" value="e53935"/>
+                <option name="EFFECT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="LINE_PARTIAL_COVERAGE">
+            <value>
+                <option name="BACKGROUND" value="38526b"/>
+            </value>
+        </option>
+        <option name="LOG_ERROR_OUTPUT">
+            <value>
+                <option name="FOREGROUND" value="ff6b68"/>
+            </value>
+        </option>
+        <option name="Label">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Line comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="List/map to object conversion">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="LUA_DEFINED_CONSTANTS" baseAttributes="DEFAULT_CONSTANT"/>
+        <option name="LUA_FIELD" baseAttributes="DEFAULT_STATIC_FIELD"/>
+        <option name="LUA_GLOBAL_VAR" baseAttributes="DEFAULT_GLOBAL_VARIABLE"/>
+        <option name="LUA_LOCAL_VAR" baseAttributes="DEFAULT_LOCAL_VARIABLE"/>
+        <option name="LUA_LUADOC" baseAttributes="DEFAULT_DOC_COMMENT"/>
+        <option name="LUA_PARAMETER" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="LUA_UPVAL" baseAttributes="LUA_LOCAL_VAR"/>
+        <option name="List/map to object conversion" baseAttributes="JAVA_NUMBER"/>
+        <option name="MACRONAME">
+            <value>
+                <option name="FOREGROUND" value="908b25"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN.AUTO_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.BULLET_LIST">
+            <value>
+                <option name="FOREGROUND" value="646877"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.EXPLICIT_LINK">
+            <value>
+                <option name="FOREGROUND" value="6dc2b8"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_1">
+            <value>
+                <option name="FOREGROUND" value="63c0ee"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_2">
+            <value>
+                <option name="FOREGROUND" value="63c0ee"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_3">
+            <value>
+                <option name="FOREGROUND" value="63c0ee"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_4">
+            <value>
+                <option name="FOREGROUND" value="63c0ee"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.HEADER_LEVEL_5">
+            <value>
+                <option name="FOREGROUND" value="63c0ee"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.IMAGE">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.MAIL_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE_IMAGE">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.REFERENCE_LINK">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN.TEXT">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_AUTO_LINK">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BLOCK_QUOTE">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BLOCK_QUOTE_MARKER">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BOLD">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_BOLD_MARKER">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_BLOCK">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_FENCE">
+            <value/>
+        </option>
+        <option name="MARKDOWN_CODE_SPAN">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_CODE_SPAN_MARKER">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_EXPLICIT_LINK">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_1">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_2">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_3">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_4">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_5">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_LEVEL_6">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HEADER_MARKER">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HRULE">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_HTML_BLOCK">
+            <value>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_IMAGE">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_INLINE_HTML">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_ITALIC">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_ITALIC_MARKER">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_DESTINATION">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_LABEL">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_TEXT">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LINK_TITLE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LIST_ITEM">
+            <value>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_LIST_MARKER">
+            <value/>
+        </option>
+        <option name="MARKDOWN_REFERENCE_LINK">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_STRIKE_THROUGH">
+            <value>
+                <option name="EFFECT_COLOR" value="a2a2a2"/>
+                <option name="EFFECT_TYPE" value="3"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_TABLE_SEPARATOR">
+            <value/>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ABBREVIATED_TEXT">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ABBREVIATION">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ABBREVIATION_EXPANDED_TEXT">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ABBREVIATION_SHORT_TEXT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ANCHOR_ID">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ATX_HEADER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.BOLD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.BULLET_LIST">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.CODE">
+            <value>
+                <option name="BACKGROUND" value="CCEAE7"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.CODE_MARKER">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="BACKGROUND" value="CCEAE7"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.DEFINITION_MARKER">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.DEFINITION_TERM">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.EMOJI_ID">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.FOOTNOTE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.FOOTNOTE_ID">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.FOOTNOTE_REF">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.HEADER_TEXT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="e65100"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.HRULE">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="EFFECT_COLOR" value="666666"/>
+                <option name="EFFECT_TYPE" value="4"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.HTML_BLOCK">
+            <value>
+                <option name="BACKGROUND" value="384753"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.HTML_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.IMAGE">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.IMAGE_ALT_TEXT">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.INLINE_HTML">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="BACKGROUND" value="CCEAE7"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.ITALIC">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.JEKYLL_FRONT_MATTER_MARKER">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.JEKYLL_TAG_MARKER">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.JEKYLL_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.QUOTED_TEXT_ABBREVIATED_TEXT">
+            <value>
+                <option name="FOREGROUND" value="c6bc82"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.QUOTED_TEXT_HTML_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="6a9f93"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.QUOTED_TEXT_SMARTS">
+            <value>
+                <option name="FOREGROUND" value="9d8a87"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.QUOTED_TEXT_SPECIAL_TEXT">
+            <value>
+                <option name="FOREGROUND" value="9ad554"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.QUOTED_TEXT_SPECIAL_TEXT_MARKER">
+            <value>
+                <option name="FOREGROUND" value="9ad554"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.REFERENCE_IMAGE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.REFERENCE_LINK">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.SETEXT_HEADER">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.SIM_TOC_TITLE">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.SMARTS">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.SPECIAL_TEXT">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.STRIKETHROUGH">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_COLOR" value="424242"/>
+                <option name="EFFECT_TYPE" value="3"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.SUBSCRIPT">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_COLOR" value="424242"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CAPTION">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CAPTION_MARKER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CELL_REVEN_CEVEN">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CELL_REVEN_CODD">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CELL_RODD_CEVEN">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE_CELL_RODD_CODD">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE_HDR_CELL_REVEN_CEVEN">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE_HDR_CELL_REVEN_CODD">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.TABLE_HDR_ROW_EVEN">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_HDR_ROW_ODD">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_ROW_EVEN">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_ROW_ODD">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_SEPARATOR">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_SEP_COLUMN_EVEN">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TABLE_SEP_COLUMN_ODD">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TASK_DONE_ITEM_MARKER">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TASK_ITEM_MARKER">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.TEXT">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.UNDERLINE">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_COLOR" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+
+        <option name="MARKDOWN_NAVIGATOR.VERBATIM">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="MARKDOWN_NAVIGATOR.WIKI_LINK">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="MATCHED_BRACE_ATTRIBUTES">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="b39613"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="MESSAGE_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="c4b3a3"/>
+            </value>
+        </option>
+        <option name="Map key">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Method call">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="NOT_TOP_FRAME_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="b2ccd6"/>
+            </value>
+        </option>
+        <option name="NOT_USED_ELEMENT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="EFFECT_COLOR" value="666666"/>
+                <option name="EFFECT_TYPE" value="4"/>
+            </value>
+        </option>
+        <option name="Number">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.BADCHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.BLOCK_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.CLASS_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="OC.COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.CONDITIONALLY_NOT_COMPILED">
+            <value/>
+        </option>
+        <option name="OC.CPP_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.DIRECTIVE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="OC.DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.ENUM_CONST">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.EXTERN_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.FORMAT_TOKEN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="OC.GENERIC_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="OC.GLOBAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.HEADER_PATH">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="OC.IVAR">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="OC.LABEL">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="OC.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.LOCAL_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.MACRONAME">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="OC.MACRO_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.MESSAGE_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="OC.NAMESPACE_LIKE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="OC.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.OVERLOADED_OPERATOR">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="OC.PROPERTY">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.PROPERTY_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="OC.PROTOCOL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="50861a"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="OC.SELFSUPERTHIS">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="OC.SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="OC.STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="OC.STRUCT_FIELD">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="OC.STRUCT_LIKE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="OC.TEMPLATE_TYPE">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="OC.TEMPLATE_VALUE">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="OC.TYPEDEF">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="PERL_ARRAY" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="PERL_ARRAY_BUILTIN" baseAttributes="PERL_ARRAY"/>
+        <option name="PERL_DQ_STRING" baseAttributes="DEFAULT_STRING"/>
+        <option name="PERL_DX_STRING" baseAttributes="DEFAULT_STRING"/>
+        <option name="PERL_EMBED_MARKER" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR"/>
+        <option name="PERL_GLOB" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="PERL_GLOB_BUILTIN" baseAttributes="PERL_GLOB"/>
+        <option name="PERL_HASH" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="PERL_HASH_BUILTIN" baseAttributes="PERL_HASH"/>
+        <option name="PERL_LABEL" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="PERL_NUMBER" baseAttributes="DEFAULT_NUMBER"/>
+        <option name="PERL_PACKAGE" baseAttributes="DEFAULT_CLASS_NAME"/>
+        <option name="PERL_PACKAGE_CORE" baseAttributes="PERL_PACKAGE"/>
+        <option name="PERL_PACKAGE_PRAGMA" baseAttributes="PERL_PACKAGE"/>
+        <option name="PERL_REGEX_TOKEN" baseAttributes="DEFAULT_STRING"/>
+        <option name="PERL_SCALAR" baseAttributes="DEFAULT_IDENTIFIER"/>
+        <option name="PERL_SCALAR_BUILTIN" baseAttributes="PERL_SCALAR"/>
+        <option name="PERL_SQ_STRING" baseAttributes="DEFAULT_STRING"/>
+        <option name="PERL_SUB" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+        <option name="PERL_SUB_BUILTIN" baseAttributes="PERL_SUB"/>
+        <option name="PERL_SUB_DEFINITION" baseAttributes="DEFAULT_FUNCTION_DECLARATION"/>
+        <option name="PERL_VERSION" baseAttributes="PERL_NUMBER"/>
+        <option name="PERL_XSUB" baseAttributes="PERL_SUB"/>
+        <option name="PHP_BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PHP_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PHP_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PHP_CLASS">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="PHP_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PHP_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PHP_CONCATENATION">
+            <value/>
+        </option>
+        <option name="PHP_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PHP_DOC_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="PHP_DOC_TAG">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PHP_ESCAPE_SEQUENCE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PHP_EXEC_COMMAND_ID">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PHP_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PHP_FUNCTION_CALL">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PHP_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PHP_HEREDOC_ID">
+            <value>
+                <option name="FONT_TYPE" value="1"/>
+                <option name="EFFECT_COLOR" value="808080"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PHP_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="PHP_INSTANCE_FIELD">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="PHP_INSTANCE_METHOD">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PHP_INTERFACE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PHP_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PHP_MARKUP_ID">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="PHP_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PHP_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PHP_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PHP_PARENTHESES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PHP_PREDEFINED SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PHP_SCRIPTING_BACKGROUND">
+            <value/>
+        </option>
+        <option name="PHP_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="PHP_STATIC_FIELD">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PHP_STATIC_METHOD">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PHP_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PHP_TAG">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PHP_VAR">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="PHP_VAR_VAR">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="POD_CODE" baseAttributes="DEFAULT_DOC_COMMENT"/>
+        <option name="POD_TAG" baseAttributes="DEFAULT_DOC_COMMENT_TAG"/>
+        <option name="POD_TEXT" baseAttributes="DEFAULT_DOC_COMMENT"/>
+        <option name="PROTOCOL_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="219598"/>
+            </value>
+        </option>
+        <option name="PY.BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.BUILTIN_NAME">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PY.CLASS_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.DECORATOR">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="PY.DOC_COMMENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.FUNC_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="PY.INVALID_STRING_ESCAPE">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PY.LINE_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PY.OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="PY.PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_DEFINITION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="PY.PREDEFINED_USAGE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="PY.SELF_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="PY.STRING.U">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="Parentheses">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="QL_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="QL_BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="QL_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="QL_DATETIME">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="QL_DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="QL_ENTITY">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="QL_FUNCTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="QL_ID_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="QL_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="QL_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="QL_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="QL_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="QL_PARENTHS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="QL_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="REST.FIXED">
+            <value>
+                <option name="BACKGROUND" value="252b39"/>
+            </value>
+        </option>
+        <option name="REST.INLINE">
+            <value>
+                <option name="BACKGROUND" value="252b39"/>
+            </value>
+        </option>
+        <option name="REST.INTERPRETED">
+            <value>
+                <option name="BACKGROUND" value="252b39"/>
+            </value>
+        </option>
+        <option name="RHTML_COMMENT_ID">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_END_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RHTML_EXPRESSION_START_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RHTML_OMIT_NEW_LINE_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTING_BACKGROUND_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_END_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RHTML_SCRIPTLET_START_ID">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_BAD_CHARACTER">
+            <value>
+                <option name="EFFECT_COLOR" value="e889b5"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RUBY_BRACES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_BRACKETS">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_COLON">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_COMMA">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_COMMENT">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="RUBY_CONSTANT_DECLARATION">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="RUBY_CVAR">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_DOT">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_ESCAPE_SEQUENCE">
+            <value/>
+        </option>
+        <option name="RUBY_EXPR_IN_STRING">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_GVAR">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_HASH_ASSOC">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_CONTENT">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="BACKGROUND" value="fafafa"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="RUBY_HEREDOC_ID">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_INTERPOLATED_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="RUBY_INVALID_ESCAPE_SEQUENCE">
+            <value>
+                <option name="EFFECT_COLOR" value="722c40"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RUBY_IVAR">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RUBY_LINE_CONTINUATION">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_LOCAL_VAR_ID">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="RUBY_METHOD_NAME">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="RUBY_NTH_REF">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="RUBY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="RUBY_OPERATION_SIGN">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RUBY_PARAMETER_ID">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="RUBY_PARENTHESES">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="RUBY_REGEXP">
+            <value>
+                <option name="BACKGROUND" value="f7faff"/>
+            </value>
+        </option>
+        <option name="RUBY_SEMICOLON">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="RUBY_STRING">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="RUBY_WORDS">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_BLOCK_TAG">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_ENTITY_REFERENCE">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_MVC_ACTION">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_MVC_AREA">
+            <value>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_MVC_CONTROLLER">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_MVC_VIEW">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_MVC_VIEW_COMPONENT">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ASP_NET_RAZOR_CODE_BLOCK">
+            <value/>
+        </option>
+        <option name="ReSharper.ASP_NET_RUN_AT_ATTRIBUTE">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="ReSharper.DELEGATE_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ReSharper.ENUM_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="ReSharper.EXTENSION_METHOD_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="ReSharper.HINT">
+            <value>
+                <option name="FOREGROUND" value="808080"/>
+                <option name="EFFECT_COLOR" value="00897b"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="ReSharper.STRUCT_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="ReSharper.TYPE_PARAMETER_IDENTIFIER">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="SASS_MIXIN">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="SASS_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <!--<option name="FOREGROUND" value="1e3445" />-->
+                <option name="BACKGROUND" value="eae8e8"/>
+            </value>
+        </option>
+        <option name="SLIM_FILTER" baseAttributes="DEFAULT_LABEL"/>
+        <option name="SLIM_FILTER_CONTENT" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR"/>
+        <option name="SLIM_ID" baseAttributes="CSS.HASH"/>
+        <option name="SLIM_RUBY_CODE" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR"/>
+        <option name="STATIC_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="SUGGESTION">
+            <value>
+                <option name="EFFECT_COLOR" value="311b92"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Abstract class">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Scala Annotation attribute name">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="Scala Annotation name">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+            </value>
+        </option>
+        <option name="Scala Anonymous Parameter">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="Scala Assign">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Bad character">
+            <value>
+                <option name="EFFECT_COLOR" value="e53935"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Block comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Braces">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Brackets">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Class">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="Scala Class method call">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="Scala Colon">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Comma">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Dot">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala For statement value">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Invalid escape in string">
+            <value>
+                <option name="EFFECT_COLOR" value="722c40"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Keyword">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Line comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala Local lazy val/var">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Local method call">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="Scala Local value">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Local variable">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Method declaration">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="Scala Number">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="Scala Object">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="Scala Object method call">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="Scala Parameter">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="Scala Parentheses">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Pattern value">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Predefined types">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala Semicolon">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+            </value>
+        </option>
+        <option name="Scala String">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Scala Template lazy val/var">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Template val">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Template var">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="Scala Trait">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Scala Type Alias">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="Scala Type parameter">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="Scala XML attribute name">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala XML attribute value">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Scala XML comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Scala XML tag">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="Scala XML tag data">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+                <option name="BACKGROUND" value="fafafa"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="Scala XML tag name">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="ScalaDoc @param value">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ScalaDoc comment">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="ScalaDoc comment tag">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="ScalaDoc html escape sequences">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="ScalaDoc html tag">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="ScalaDoc wiki syntax elements">
+            <value>
+                <option name="FOREGROUND" value="666666"/>
+            </value>
+        </option>
+        <option name="Scalatest keyword">
+            <value>
+                <option name="FOREGROUND" value="311b92"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Static field">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="Static method access">
+            <value>
+                <option name="FOREGROUND" value="1565c0"/>
+            </value>
+        </option>
+        <option name="Static property reference ID">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+                <option name="EFFECT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="String">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="TAPESTRY_COMPONENT_TAG">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="bd92ea"/>
+            </value>
+        </option>
+        <option name="TEXT">
+            <value>
+                <option name="FOREGROUND" value="424242"/>
+                <option name="BACKGROUND" value="fafafa"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="272727"/>
+                <option name="BACKGROUND" value="f8e71c"/>
+                <option name="EFFECT_COLOR" value="f8e71c"/>
+            </value>
+        </option>
+        <option name="TODO_DEFAULT_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="TS.TYPE_PARAMETER">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+            </value>
+        </option>
+        <option name="TYPEDEF">
+            <value>
+                <option name="FOREGROUND" value="c7c8f5"/>
+            </value>
+        </option>
+        <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="TYPO">
+            <value>
+                <option name="EFFECT_COLOR" value="c17e70"/>
+                <option name="EFFECT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="Trait name">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="Type parameter">
+            <value>
+                <option name="FOREGROUND" value="e65100"/>
+            </value>
+        </option>
+        <option name="UNMATCHED_BRACE_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="d1243b"/>
+            </value>
+        </option>
+        <option name="Unresolved reference access">
+            <value>
+                <option name="FOREGROUND" value="000000"/>
+            </value>
+        </option>
+        <option name="VELOCITY_KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="VELOCITY_NUMBER">
+            <value>
+                <option name="FOREGROUND" value="f36e3a"/>
+            </value>
+        </option>
+        <option name="VELOCITY_SCRIPTING_BACKGROUND">
+            <value>
+                <option name="BACKGROUND" value="252b39"/>
+            </value>
+        </option>
+        <option name="Valid string escape">
+            <value>
+                <option name="FOREGROUND" value="91b859"/>
+            </value>
+        </option>
+        <option name="WARNING_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="ffa000"/>
+                <option name="ERROR_STRIPE_COLOR" value="ffa000"/>
+                <option name="EFFECT_TYPE" value="4"/>
+            </value>
+        </option>
+        <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+            <value>
+                <option name="EFFECT_COLOR" value="424242"/>
+                <option name="ERROR_STRIPE_COLOR" value="65737e"/>
+            </value>
+        </option>
+        <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+            <value>
+                <option name="BACKGROUND" value="FAFAFA"/>
+            </value>
+        </option>
+        <option name="WRONG_REFERENCES_ATTRIBUTES">
+            <value>
+                <option name="FOREGROUND" value="bc3f3c"/>
+            </value>
+        </option>
+        <option name="XML_NS_PREFIX">
+            <value>
+                <option name="FOREGROUND" value="ffa000"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="XML_PROLOGUE" baseAttributes="TEXT"/>
+        <option name="XML_TAG">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+            </value>
+        </option>
+        <option name="XML_TAG_NAME">
+            <value>
+                <option name="FOREGROUND" value="ff355b"/>
+            </value>
+        </option>
+        <option name="XPATH.XPATH_NAME">
+            <value>
+                <option name="FOREGROUND" value="1a1f29"/>
+            </value>
+        </option>
+        <option name="XPATH.XPATH_VARIABLE">
+            <value>
+                <option name="FOREGROUND" value="f38630"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+        <option name="com.plan9.INSTRUCTION" baseAttributes="DEFAULT_PREDEFINED_SYMBOL"/>
+        <option name="com.plan9.LABEL" baseAttributes="DEFAULT_LABEL"/>
+        <option name="YAML_SCALAR_KEY">
+            <value>
+                <option name="FOREGROUND" value="e53935"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_LIST">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="YAML_SCALAR_VALUE">
+            <value>
+                <option name="FOREGROUND" value="00897b"/>
+                <option name="BACKGROUND" value="fafafa"/>
+                <option name="EFFECT_TYPE" value="5"/>
+            </value>
+        </option>
+        <option name="osmorc.headerName">
+            <value>
+                <option name="FOREGROUND" value="a7dbd8"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+    </attributes>
+</scheme>


### PR DESCRIPTION
As discussed in #783, here's an imo better version of the Material Lighter editor theme. Please feel free to try it out and criticize all you want, this is my first editor theme :stuck_out_tongue:

### Palette:
- `#000000` for instance fields, much darker and perfect contrast - However, this is the only thing I'm not 100% happy about
- `#666666` / 60% black on white (Material secondary text) for comments, line numbers
- `#311b92`, aka Purple 900 for keywords (method return type, annotations, constants)
- `#1565c0`, aka Blue 800 for function/method calls, definitions
- `#ffa000`, aka Amber 700 for class names
- `#e65100`, aka Orange 900 for parameters, numbers, etc.
- `#00897b`, aka Teal 600 for brackets, braces, operators, dots
- `#212121`, `#424242`, and `#eeeeee`, aka Gray 900, 800, and 200 in a lot of other places (Doc parameters, highlighting, etc)
- some more..

### Screenshot
![Preview](https://user-images.githubusercontent.com/5903699/40330227-9301befa-5d4c-11e8-8b13-543dedaa18aa.png)
