### PR TITLE
Add typescript option for Webpack icon

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -295,7 +295,7 @@
         <regex name="Visual Studio" pattern=".*\.(vscode|vssettings).*" icon="/icons/files/vs.svg"/>
 
         <regex name="Vue" pattern=".*\.(vue|vuex)$" icon="/icons/files/vue.svg"/>
-        <regex name="Webpack" pattern="webpack\.(common|config|dev|prod)\.(js|es|es6|coffee)$"
+        <regex name="Webpack" pattern="webpack\.(common|config|dev|prod)\.(js|es|es6|coffee|ts)$"
                icon="/icons/files/webpack.svg"/>
         <regex name="Word" pattern=".*\.(doc|docx|docm|docxml|dotm|dotx|wri|odt|odtx)$" icon="/icons/files/word.svg"/>
         <regex name="Windows" pattern=".*\.(bat|exe|dos|ms)$" icon="/icons/files/windows.svg"/>


### PR DESCRIPTION
Add `ts` to webpack regex pattern

As Webpack can be written in Typescript it seems to make sense to use the wekback icon for webpack.[dev|prod].ts

#### Description

Add `|ts` to webpack  regex pattern

#### Motivation and Context

I write my webpack files in Typescript and would like the icon to match

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.