### PR TITLE
swagger file icon association extended regex

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -266,7 +266,8 @@
         <regex name="Sublime" pattern=".*\.sublime.*$" icon="/icons/files/sublime.svg"/>
         <!--<regex name="SVG" pattern=".*\.svg$" icon="/icons/files/svg.svg"/>-->
         <regex name="SVN" pattern=".*\.svn.*$" icon="/icons/files/svn.svg"/>
-        <regex name="Swagger" pattern=".*\.(swagger|swag|apib)$" icon="/icons/files/swagger.svg"/>
+        <regex name="Swagger" pattern="(.*\.(?:swagger|swag|apib))|(\.?(swagger|api)\.(yml|yaml|json))$" 
+               icon="/icons/files/swagger.svg"/>
         <regex name="Swift" pattern=".*\.swift$" icon="/icons/files/swift.svg"/>
         <regex name="Swig" pattern=".*\.swig$" icon="/icons/files/swig.svg"/>
         <regex name="Symfony" pattern=".*symfony.*$" icon="/icons/files/symfony.svg"/>


### PR DESCRIPTION
Regex to associate open API icon to swagger file extended to match names like `swagger.yaml` and similar

#### Motivation and Context

This adds an open API icon to the swagger file when it is named like the swagger default file

#### How Has This Been Tested?

Only in regex validator.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.