### PR TITLE
Added ids to iconProviders

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -75,8 +75,8 @@
 
         <projectViewNodeDecorator implementation="com.chrisrm.idea.tree.MTProjectViewNodeDecorator"/>
         <editorTabTitleProvider implementation="com.chrisrm.idea.tabs.MTEditorUpperTabs" order="first"/>
-        <iconProvider implementation="com.chrisrm.idea.icons.MTHiddenIconProvider" order="first"/>
-        <iconProvider implementation="com.chrisrm.idea.icons.MTFileIconProvider" order="first"/>
+        <iconProvider implementation="com.chrisrm.idea.icons.MTHiddenIconProvider" order="first" id="MTHiddenIconProvider"/>
+        <iconProvider implementation="com.chrisrm.idea.icons.MTFileIconProvider" order="first" id="MTFileIconProvider"/>
 
         <bundledColorScheme path="/colors/Material Lighter"/>
         <bundledColorScheme path="/colors/Material Oceanic"/>


### PR DESCRIPTION
#### Description
IconProvider have tag **order** which moves yours providers before others. But if another plugin wants to return more specific icon, rather than generic one here starts a problems. With **id** tag another plugin can put himself before or after your provider.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.