### PR TITLE
Small Classloading Change 

### DIFF
--- a/src/main/java/com/chrisrm/idea/MTHackComponent.java
+++ b/src/main/java/com/chrisrm/idea/MTHackComponent.java
@@ -31,7 +31,7 @@ import com.intellij.ide.plugins.PluginManagerConfigurable;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.impl.ChameleonAction;
 import com.intellij.openapi.components.ApplicationComponent;
-import com.intellij.openapi.wm.impl.IdeBackgroundUtil;
+import com.intellij.openapi.wm.impl.ColorThief;
 import com.intellij.openapi.wm.impl.IdeFocusManagerImpl;
 import com.intellij.openapi.wm.impl.ToolWindowImpl;
 import com.intellij.openapi.wm.impl.welcomeScreen.FlatWelcomeFrameProvider;
@@ -206,7 +206,7 @@ public class MTHackComponent implements ApplicationComponent {
     // Hack method
     try {
       final ClassPool cp = new ClassPool(true);
-      cp.insertClassPath(new ClassClassPath(IdeBackgroundUtil.class));
+      cp.insertClassPath(new ClassClassPath(ColorThief.class));
       final CtClass ctClass = cp.get("com.intellij.openapi.wm.impl.IdePanePanel");
 
       final CtMethod paintBorder = ctClass.getDeclaredMethod("getBackground");


### PR DESCRIPTION
 #### Motivation and Context
I want to modify the source code of `IdeBackgroundUtil` in another plugin and having _this_ plugin load into the classpath makes this inconvenient (We share the same thread). Yes, I know that classes can be reloaded (but I have not gotten it to work). 

So instead of learning more than I would like about Java class loading, I figured I could just change this.
It still loads another class in the same package, so the `IdePanePanel` still gets modified :) 

#### How Has This Been Tested?
It works/runs on the following environments:

```
IntelliJ IDEA 2018.2.4 EAP (Ultimate Edition)
Build #IU-182.4505.7, built on September 5, 2018
JRE: 1.8.0_152-release-1248-b8 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
macOS 10.13.6
```

```
IntelliJ IDEA 2018.2.4 EAP (Ultimate Edition)
Build #IU-182.4505.7, built on September 5, 2018
JRE: 1.8.0_152-release-1248-b8 amd64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-36-generic
```

```
IntelliJ IDEA 2018.2.4 EAP (Ultimate Edition)
Build #IU-182.4505.7, built on September 5, 2018
JRE: 1.8.0_152-release-1248-b8 amd64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Windows 10 10.0
```
#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non Functional change (No changes that the user can see)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.


### Thanks in advance!