### PR TITLE
Added reference to find material_theme.xml

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -47,6 +47,6 @@ It should contain:
 * If needed a list of enabled plugins
 * Material Theme Plugin version
 
-If possible please also give out your Material Theme/Material Custom Theme configuration file.
+If possible please also give out your Material Theme/Material Custom Theme configuration file. To find your configuration file, see: https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs. On Ubuntu this could be `~/.IntelliJIdea2019.1/config/options` for example.
 
 Note that not providing any of the required info will result of your issue being closed.


### PR DESCRIPTION
#### Description
The current issue template mentions to get some information from a material_theme.xml, but does not specify where to find this file.

#### Motivation and Context
This should make it easier for people to open an issue. I'm not 100% if the current change is the most ideal. If you have a better idea, I'll update the PR.

#### How Has This Been Tested?
n/a

#### Screenshots (if appropriate):
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.