### PR TITLE
Completion Window Background Issue Fix

### DIFF
--- a/src/main/java/com/chrisrm/idea/UIReplacer.java
+++ b/src/main/java/com/chrisrm/idea/UIReplacer.java
@@ -261,13 +261,11 @@ public enum UIReplacer {
    * theme.
    */
   static void patchCompletionPopup() {
-    MTConfig mtConfig = MTConfig.getInstance();
-    if (!mtConfig.isMaterialTheme()) {
+    if (!MTConfig.getInstance().isMaterialTheme()) {
       return;
     }
 
-    final Color defaultValue = MTUI.Panel.getSecondaryBackground();
-    final Color autoCompleteBackground = ObjectUtils.notNull(UIManager.getColor("CompletionPopup.background"), defaultValue);
+    final Color autoCompleteBackground = MTUI.Panel.getSecondaryBackground();
     try {
       Field backgroundColorField = LookupCellRenderer.class.getDeclaredField("BACKGROUND_COLOR");
         StaticPatcher.setFinalStatic(backgroundColorField, autoCompleteBackground);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Apparently the completion background is set to the theme's `DOCUMENTATION_COLOR` color key on startup, and does not change if the theme is changed by the user while the project is open.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#1249 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works on this environment
```
IntelliJ IDEA 2019.2 EAP (Community Edition)
Build #IC-192.5118.30, built on June 13, 2019
Runtime version: 1.8.0_212-release-1586-b4 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
macOS 10.14.5
```
Also if you change the theme a bunch of times (like 5 times or more, the background color stops changing and sticks to one). That behaviour is flaky and hard to reproduce.  However, casually changing themes this works just fine.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.