### PR TITLE
rename 'procfile' icon and assign it also to '.slugignore' file

### DIFF
--- a/src/main/resources/icon_associations.xml
+++ b/src/main/resources/icon_associations.xml
@@ -178,6 +178,7 @@
         <regex name="Hashicorp" pattern=".*\.hcl$" icon="/icons/files/hcl.svg"/>
         <regex name="Haskell" pattern=".*\.(haskell|hs)$" icon="/icons/files/haskell.svg"/>
         <regex name="Haxe" pattern=".*\.(haxe|hx)$" icon="/icons/files/haxe.svg"/>
+        <regex name="Heroku" pattern="^((P|p)rocfile(\.windows)?|\.slugignore)$" icon="/icons/files/heroku.svg"/>
         <regex name="HTAccess" pattern=".*\.(htaccess|htpasswd)$" icon="/icons/files/htaccess.svg"/>
         <regex name="HTML" pattern=".*\.(html|htm)$" icon="/icons/files/html.svg"/>
         <regex name="Husky" pattern=".*\.huskyrc(.js(on)?)?$" icon="/icons/files/husky.svg"/>
@@ -273,7 +274,6 @@
         <regex name="Premiere" pattern=".*\.(prel|prproj|psq)$" icon="/icons/files/premiere.svg"/>
         <regex name="Prettier" pattern="^\.prettierrc(\.js(on)?|\.y(a)?ml)?$" icon="/icons/files/prettier.svg"/>
         <regex name="Prettier Config" pattern="^prettier\.config\.js$" icon="/icons/files/prettier.svg"/>
-        <regex name="Procfile" pattern="^(P|p)rocfile(\.windows)?$" icon="/icons/files/procfile.svg"/>
         <regex name="Prolog" pattern=".*\.(pro|prolog)$" icon="/icons/files/prolog.svg"/>
         <regex name="Properties" pattern=".*\.properties$" icon="/icons/files/source.svg"/>
         <regex name="Protractor" pattern="^protractor\.js(on)?$" icon="/icons/files/protractor.svg"/>

--- a/src/main/resources/icons/files/heroku.svg
+++ b/src/main/resources/icons/files/heroku.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 -1 16 16">
-    <path id="file_type_procfile.svg" class="i-color" fill="#7963E6"
+    <path class="i-color" fill="#7963E6"
           d="M9.442,13V6.437s0.441-1.57-5.431.642C4,7.108,4,1.011,4,1.011L5.919,1V4.906s5.372-2.048,5.372,1.553V13H9.442Zm1.093-9.636H8.5A12.084,12.084,0,0,0,9.9,1.011H12a9.678,9.678,0,0,1-1.465,2.353h0Zm-6.5,9.625V9.251l1.93,1.869-1.93,1.868h0Z"
           transform="translate(0 0)"/>
 </svg>


### PR DESCRIPTION
#### Description
* rename `procfile.svg` to `heroku.svg`
* associate `.slugignore` with `heroku.svg`
* remove unnecessary identifier from SVG `path`

#### Motivation and Context
I have renamed icon to avoid future confusion. Both files are strictly related to Heroku platform and icon represents the platform logo.

`.slugignore` file in Heroku documentation: 
https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore

#### How Has This Been Tested?
Local build

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.