### PR TITLE
Updated Jupyter Notebook's Selected cell color

### DIFF
--- a/src/main/resources/colors/Arc Dark.xml
+++ b/src/main/resources/colors/Arc Dark.xml
@@ -1005,6 +1005,11 @@
                 <option name="FOREGROUND" value="a7a7a7"/>
             </value>
         </option>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="3e424d" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_BACKING_FIELD_VARIABLE">
             <value/>

--- a/src/main/resources/colors/Atom One Dark.xml
+++ b/src/main/resources/colors/Atom One Dark.xml
@@ -1136,6 +1136,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="3a3f4b" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION">
             <value>
                 <option name="FOREGROUND" value="c679dd"/>

--- a/src/main/resources/colors/Atom One Light.xml
+++ b/src/main/resources/colors/Atom One Light.xml
@@ -1131,6 +1131,11 @@
                 <option name="EFFECT_TYPE" value="5"/>
             </value>
         </option>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="eaeaeb" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION">
             <value>
                 <option name="FOREGROUND" value="a626a4"/>

--- a/src/main/resources/colors/Dracula.xml
+++ b/src/main/resources/colors/Dracula.xml
@@ -919,6 +919,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="333646" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION">
             <value>
                 <option name="FOREGROUND" value="50fa78"/>

--- a/src/main/resources/colors/Material Darker.xml
+++ b/src/main/resources/colors/Material Darker.xml
@@ -1132,6 +1132,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="323232" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_BACKING_FIELD_VARIABLE">
             <value/>

--- a/src/main/resources/colors/Material Deep Ocean.xml
+++ b/src/main/resources/colors/Material Deep Ocean.xml
@@ -1120,6 +1120,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="292d3e" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_BACKING_FIELD_VARIABLE">
             <value/>

--- a/src/main/resources/colors/Material Lighter.xml
+++ b/src/main/resources/colors/Material Lighter.xml
@@ -1091,6 +1091,11 @@
                 <option name="FOREGROUND" value="7c4dff"/>
             </value>
         </option>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="F5F5F5" />
+            </value>
+        </option>
         <option name="KOTLIN_COLON">
             <value>
                 <option name="FOREGROUND" value="39adb5"/>

--- a/src/main/resources/colors/Material Oceanic.xml
+++ b/src/main/resources/colors/Material Oceanic.xml
@@ -528,6 +528,11 @@
                 <option name="FOREGROUND" value="82aaff"/>
             </value>
         </option>
+        <option name="SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="411F7E"/>
+            </value>
+        </option>
         <option name="DEFAULT_INTERFACE_NAME">
             <value>
                 <option name="FOREGROUND" value="c3e88d"/>
@@ -1124,6 +1129,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+          <value>
+            <option name="BACKGROUND" value="32424A" />
+          </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_BACKING_FIELD_VARIABLE">
             <value/>

--- a/src/main/resources/colors/Material Palenight.xml
+++ b/src/main/resources/colors/Material Palenight.xml
@@ -1113,6 +1113,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="34324a" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_BACKING_FIELD_VARIABLE">
             <value/>

--- a/src/main/resources/colors/Monokai Pro.xml
+++ b/src/main/resources/colors/Monokai Pro.xml
@@ -1105,6 +1105,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="403E41" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_ARROW">
             <value>

--- a/src/main/resources/colors/Solarized Dark.xml
+++ b/src/main/resources/colors/Solarized Dark.xml
@@ -1377,6 +1377,11 @@
             </value>
         </option>
         <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD"/>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="073642" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_AUTO_CASTED_VALUE">
             <value>

--- a/src/main/resources/colors/Solarized Light.xml
+++ b/src/main/resources/colors/Solarized Light.xml
@@ -1362,6 +1362,11 @@
         <option name="JSP_DIRECTIVE_BACKGROUND">
             <value/>
         </option>
+        <option name="JUPYTER_SELECTED_CELL">
+            <value>
+                <option name="BACKGROUND" value="F6F4D7" />
+            </value>
+        </option>
         <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES"/>
         <option name="KOTLIN_AUTO_CASTED_VALUE">
             <value>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
I've updated the default selected cell in a Jupyter notebook.
I also did my best to re-use the theme palette when possible.

I did _not_ change the `GitHub` Theme as it looks okay, in my opinion.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The default selected cell does not go well with some of the themes. 
Plus, most of your time in a Jupyter notebook is staring at the selected cell that you are editing, so I feel like it needs to be updated.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
Works in this environment
```
PyCharm 2019.2 (Professional Edition)
Build #PY-192.5728.105, built on July 23, 2019
Subscription is active until February 21, 2020
Runtime version: 11.0.3+12-b304.10 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
macOS 10.14.5
```
#### Screenshots (if appropriate):
I'll comment the before and after screens.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.