### PR TITLE
Prevent memory leak on application close.

### DIFF
--- a/src/main/java/com/mallowigi/idea/MTThemeManager.java
+++ b/src/main/java/com/mallowigi/idea/MTThemeManager.java
@@ -32,6 +32,7 @@ import com.intellij.ide.ui.UITheme;
 import com.intellij.ide.ui.laf.LafManagerImpl;
 import com.intellij.ide.ui.laf.darcula.DarculaInstaller;
 import com.intellij.ide.ui.laf.darcula.DarculaLaf;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
@@ -80,7 +81,7 @@ import java.util.Locale;
   "DuplicateStringLiteralInspection",
   "UtilityClassCanBeEnum",
   "UtilityClass"})
-public final class MTThemeManager {
+public final class MTThemeManager implements Disposable {
 
   /**
    * The constant DEFAULT_FONT.
@@ -727,5 +728,10 @@ public final class MTThemeManager {
       DarculaInstaller.install();
     }
     LafManager.getInstance().updateUI();
+  }
+
+  @Override
+  public void dispose() {
+
   }
 }

--- a/src/main/java/com/mallowigi/idea/notifications/Notify.java
+++ b/src/main/java/com/mallowigi/idea/notifications/Notify.java
@@ -34,6 +34,8 @@ import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.BalloonLayoutData;
 import com.intellij.ui.awt.RelativePoint;
+import com.mallowigi.idea.MTConfig;
+import com.mallowigi.idea.MTThemeManager;
 import com.mallowigi.idea.messages.MaterialThemeBundle;
 import com.mallowigi.idea.utils.MTUiUtils;
 import org.jetbrains.annotations.NonNls;
@@ -153,8 +155,7 @@ public enum Notify {
           true,
           true,
           BalloonLayoutData.fullContent(),
-          () -> {
-          }
+          MTThemeManager.getInstance()
         );
         // Display the balloon at the top right
         balloon.show(target, Balloon.Position.atLeft);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

- Added a plugin service as a parent disposable for the update notification.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When you update the plugin and the notification displays, when you close the IDE it [becomes very angry in the logs](https://pastebin.com/mj30rLVi) because of a memory leak.

I just made the theme manager disposable, because Intellij complained when I used the project reference. I think they want you to use a plugin service if nothing else. [You can read more about these here if you are curious.](https://jetbrains.org/intellij/sdk/docs/basics/disposers.html#choosing-a-disposable-parent)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->

The error goes away when I put the theme manager in there, and it comes back if I remove it. This only happens when the update notification is displayed.

Works on:
```
IntelliJ IDEA 2020.2 Beta (Ultimate Edition)
Build #IU-202.6397.20, built on July 15, 2020
IntelliJ IDEA EAP User
Expiration date: August 14, 2020
Runtime version: 11.0.7+10-b944.20 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Linux 4.15.0-109-generic
GC: G1 Young Generation, G1 Old Generation
Memory: 512M
Cores: 12
Registry: ide.balloon.shadow.size=0
Non-Bundled Plugins: com.chrisrm.idea.MaterialThemeUI
Current Desktop: ubuntu:GNOME
```

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.